### PR TITLE
Use RateLimitingSampler.update()

### DIFF
--- a/src/samplers/guaranteed_throughput_sampler.js
+++ b/src/samplers/guaranteed_throughput_sampler.js
@@ -83,8 +83,7 @@ export default class GuaranteedThroughputSampler {
             updated = true;
         }
         if (this._lowerBoundSampler.maxTracesPerSecond != lowerBound) {
-            this._lowerBoundSampler = new RateLimitingSampler(lowerBound);
-            updated = true;
+            updated = this._lowerBoundSampler.update(lowerBound);
         }
         return updated;
     }

--- a/src/samplers/ratelimiting_sampler.js
+++ b/src/samplers/ratelimiting_sampler.js
@@ -19,13 +19,27 @@ export default class RateLimitingSampler {
     _maxTracesPerSecond: number;
 
     constructor(maxTracesPerSecond: number) {
+        this._init(maxTracesPerSecond);
+    }
+
+    update(maxTracesPerSecond: number): boolean {
+        let prevMaxTracesPerSecond = this._maxTracesPerSecond;
+        this._init(maxTracesPerSecond);
+        return this._maxTracesPerSecond !== prevMaxTracesPerSecond;
+    }
+
+    _init(maxTracesPerSecond: number) {
         if (maxTracesPerSecond < 0) {
             throw new Error(`maxTracesPerSecond must be greater than 0.0.  Received ${maxTracesPerSecond}`);
         }
         let maxBalance = maxTracesPerSecond < 1.0 ? 1.0 : maxTracesPerSecond;
 
         this._maxTracesPerSecond = maxTracesPerSecond;
-        this._rateLimiter = new RateLimiter(maxTracesPerSecond, maxBalance);
+        if (this._rateLimiter) {
+            this._rateLimiter.update(maxTracesPerSecond, maxBalance);
+        } else {
+            this._rateLimiter = new RateLimiter(maxTracesPerSecond, maxBalance);
+        }
     }
 
     name(): string {

--- a/src/samplers/ratelimiting_sampler.js
+++ b/src/samplers/ratelimiting_sampler.js
@@ -18,8 +18,8 @@ export default class RateLimitingSampler {
     _rateLimiter: RateLimiter;
     _maxTracesPerSecond: number;
 
-    constructor(maxTracesPerSecond: number) {
-        this._init(maxTracesPerSecond);
+    constructor(maxTracesPerSecond: number, initBalance: ?number) {
+        this._init(maxTracesPerSecond, initBalance);
     }
 
     update(maxTracesPerSecond: number): boolean {
@@ -28,7 +28,7 @@ export default class RateLimitingSampler {
         return this._maxTracesPerSecond !== prevMaxTracesPerSecond;
     }
 
-    _init(maxTracesPerSecond: number) {
+    _init(maxTracesPerSecond: number, initBalance: ?number) {
         if (maxTracesPerSecond < 0) {
             throw new Error(`maxTracesPerSecond must be greater than 0.0.  Received ${maxTracesPerSecond}`);
         }
@@ -38,7 +38,7 @@ export default class RateLimitingSampler {
         if (this._rateLimiter) {
             this._rateLimiter.update(maxTracesPerSecond, maxBalance);
         } else {
-            this._rateLimiter = new RateLimiter(maxTracesPerSecond, maxBalance);
+            this._rateLimiter = new RateLimiter(maxTracesPerSecond, maxBalance, initBalance);
         }
     }
 

--- a/src/samplers/remote_sampler.js
+++ b/src/samplers/remote_sampler.js
@@ -158,7 +158,12 @@ export default class RemoteControlledSampler {
             newSampler = new ProbabilisticSampler(samplingRate);
         } else if (response.strategyType === RATELIMITING_STRATEGY_TYPE && response.rateLimitingSampling) {
             let maxTracesPerSecond = response.rateLimitingSampling.maxTracesPerSecond;
-            newSampler = new RateLimitingSampler(maxTracesPerSecond);
+            if (this._sampler instanceof RateLimitingSampler) {
+                let sampler: RateLimitingSampler = this._sampler;
+                return sampler.update(maxTracesPerSecond);
+            }
+            this._sampler = new RateLimitingSampler(maxTracesPerSecond);
+            return true;
         } else {
             throw 'Malformed response: ' + JSON.stringify(response);
         }

--- a/test/samplers/all_samplers.js
+++ b/test/samplers/all_samplers.js
@@ -59,7 +59,7 @@ describe('All samplers', () => {
             {sampler: new ConstSampler(true), 'type': constants.SAMPLER_TYPE_CONST, param: true, decision: true},
             {sampler: new ConstSampler(false), 'type': constants.SAMPLER_TYPE_CONST, param: false, decision: false},
             {sampler: new ProbabilisticSampler(1.0), 'type': constants.SAMPLER_TYPE_PROBABILISTIC, param: 1.0, decision: true},
-            {sampler: new RateLimitingSampler(0.0001, 1.0), 'type': constants.SAMPLER_TYPE_RATE_LIMITING, param: 0.0001, decision: false},
+            {sampler: new RateLimitingSampler(0.0001, 0), 'type': constants.SAMPLER_TYPE_RATE_LIMITING, param: 0.0001, decision: false},
             {
                 sampler: new RemoteSampler('some-caller-name', {sampler: new ProbabilisticSampler(1.0)}),
                 'type': constants.SAMPLER_TYPE_PROBABILISTIC,

--- a/test/samplers/all_samplers.js
+++ b/test/samplers/all_samplers.js
@@ -55,11 +55,13 @@ describe('All samplers', () => {
     });
 
     describe('should return correct tags', () => {
+        let rateLimitingSampler = new RateLimitingSampler(0.1)
+        rateLimitingSampler._rateLimiter._balance = 0;
         var samplers = [
             {sampler: new ConstSampler(true), 'type': constants.SAMPLER_TYPE_CONST, param: true, decision: true},
             {sampler: new ConstSampler(false), 'type': constants.SAMPLER_TYPE_CONST, param: false, decision: false},
             {sampler: new ProbabilisticSampler(1.0), 'type': constants.SAMPLER_TYPE_PROBABILISTIC, param: 1.0, decision: true},
-            {sampler: new RateLimitingSampler(0.1), 'type': constants.SAMPLER_TYPE_RATE_LIMITING, param: 0.1, decision: false},
+            {sampler: rateLimitingSampler, 'type': constants.SAMPLER_TYPE_RATE_LIMITING, param: 0.1, decision: false},
             {
                 sampler: new RemoteSampler('some-caller-name', {sampler: new ProbabilisticSampler(1.0)}),
                 'type': constants.SAMPLER_TYPE_PROBABILISTIC,
@@ -101,14 +103,12 @@ describe('ConstSampler', () => {
 
     it ('does NOT equal another type of sampler', () => {
         let otherSampler = new ProbabilisticSampler(0.5);
-        let equals = sampler.equal(otherSampler);
-        assert.isNotOk(equals);
+        assert.isNotOk(sampler.equal(otherSampler));
     });
 
     it ('does equal the same type of sampler', () => {
         let otherSampler = new ConstSampler(true);
-        let equals = sampler.equal(otherSampler);
-        assert.isOk(equals);
+        assert.isOk(sampler.equal(otherSampler));
     });
 });
 
@@ -122,5 +122,11 @@ describe('ProbabilisticSampler', () => {
         let tags = {};
         assert.isNotOk(sampler.isSampled('operation', tags));
         assert.deepEqual(tags, {});
+    });
+
+    it ('does NOT equal another type of sampler', () => {
+        let sampler = new ProbabilisticSampler(0.0);
+        let otherSampler = new ConstSampler(true);
+        assert.isNotOk(sampler.equal(otherSampler));
     });
 });

--- a/test/samplers/all_samplers.js
+++ b/test/samplers/all_samplers.js
@@ -55,13 +55,11 @@ describe('All samplers', () => {
     });
 
     describe('should return correct tags', () => {
-        let rateLimitingSampler = new RateLimitingSampler(0.1)
-        rateLimitingSampler._rateLimiter._balance = 0;
         var samplers = [
             {sampler: new ConstSampler(true), 'type': constants.SAMPLER_TYPE_CONST, param: true, decision: true},
             {sampler: new ConstSampler(false), 'type': constants.SAMPLER_TYPE_CONST, param: false, decision: false},
             {sampler: new ProbabilisticSampler(1.0), 'type': constants.SAMPLER_TYPE_PROBABILISTIC, param: 1.0, decision: true},
-            {sampler: rateLimitingSampler, 'type': constants.SAMPLER_TYPE_RATE_LIMITING, param: 0.1, decision: false},
+            {sampler: new RateLimitingSampler(1.0, 1.0), 'type': constants.SAMPLER_TYPE_RATE_LIMITING, param: 1.0, decision: true},
             {
                 sampler: new RemoteSampler('some-caller-name', {sampler: new ProbabilisticSampler(1.0)}),
                 'type': constants.SAMPLER_TYPE_PROBABILISTIC,

--- a/test/samplers/all_samplers.js
+++ b/test/samplers/all_samplers.js
@@ -59,7 +59,7 @@ describe('All samplers', () => {
             {sampler: new ConstSampler(true), 'type': constants.SAMPLER_TYPE_CONST, param: true, decision: true},
             {sampler: new ConstSampler(false), 'type': constants.SAMPLER_TYPE_CONST, param: false, decision: false},
             {sampler: new ProbabilisticSampler(1.0), 'type': constants.SAMPLER_TYPE_PROBABILISTIC, param: 1.0, decision: true},
-            {sampler: new RateLimitingSampler(1.0, 1.0), 'type': constants.SAMPLER_TYPE_RATE_LIMITING, param: 1.0, decision: true},
+            {sampler: new RateLimitingSampler(0.0001, 1.0), 'type': constants.SAMPLER_TYPE_RATE_LIMITING, param: 0.0001, decision: false},
             {
                 sampler: new RemoteSampler('some-caller-name', {sampler: new ProbabilisticSampler(1.0)}),
                 'type': constants.SAMPLER_TYPE_PROBABILISTIC,

--- a/test/samplers/guaranteed_throughput_sampler.js
+++ b/test/samplers/guaranteed_throughput_sampler.js
@@ -40,8 +40,10 @@ describe('GuaranteedThroughput sampler', () => {
     });
 
     it('should provide minimum throughput', () => {
+        let initialDate = new Date(2011,9,1).getTime();
+        let clock = sinon.useFakeTimers(initialDate);
         let sampler = new GuaranteedThroughputSampler(2, 0);
-        sampler._lowerBoundSampler._rateLimiter._balance = 2;
+        clock = sinon.useFakeTimers(initialDate + 20000);
 
         let expectedTags = {'sampler.type': 'lowerbound', 'sampler.param': 0};
         [true, true, false].forEach((expectedDecision) => {
@@ -59,6 +61,7 @@ describe('GuaranteedThroughput sampler', () => {
             }
         });
 
+        clock.restore();
         sampler.close();
     });
 
@@ -108,8 +111,10 @@ describe('GuaranteedThroughput sampler', () => {
     });
 
     it('should become probabilistic after minimum throughput', () => {
+        let initialDate = new Date(2011,9,1).getTime();
+        let clock = sinon.useFakeTimers(initialDate);
         let sampler = new GuaranteedThroughputSampler(2, 1.0);
-        sampler._lowerBoundSampler._rateLimiter._balance = 2;
+        clock = sinon.useFakeTimers(initialDate + 20000);
 
         let expectedTagsLB = {'sampler.type': 'lowerbound', 'sampler.param': 0.0};
         let expectedTagsProb = {'sampler.type': 'probabilistic', 'sampler.param': 1.0};
@@ -147,6 +152,7 @@ describe('GuaranteedThroughput sampler', () => {
             }
         });
 
+        clock.restore();
         sampler.close();
     });
 });

--- a/test/samplers/guaranteed_throughput_sampler.js
+++ b/test/samplers/guaranteed_throughput_sampler.js
@@ -90,7 +90,7 @@ describe('GuaranteedThroughput sampler', () => {
         let isUpdated: boolean = sampler.update(3, 1.0);
         assert.isTrue(isUpdated);
         assert.strictEqual(sampler._probabilisticSampler, p1);
-        assert.isNotOk(p2 === sampler._lowerBoundSampler);
+        assert.strictEqual(sampler._lowerBoundSampler, p2, 'lowerbound sampler should only be updated, not recreated');
         assertValues(sampler, 3, 1.0);
     });
 

--- a/test/samplers/ratelimiting_sampler_test.js
+++ b/test/samplers/ratelimiting_sampler_test.js
@@ -23,7 +23,7 @@ describe ('RateLimitingSampler should', () => {
         let sampler = new RateLimitingSampler(10);
         sampler._rateLimiter._balance = 10;
         for (let i = 0; i < 10; i++) {
-            assert.equal(sampler.isSampled('operation', {}), true, 'expected decision to be true');
+            assert.isTrue(sampler.isSampled('operation', {}), 'expected decision to be true');
         }
 
         assert.equal(sampler.maxTracesPerSecond, 10);
@@ -31,13 +31,13 @@ describe ('RateLimitingSampler should', () => {
 
         let tags = {};
         let decision = sampler.isSampled('operation', tags);
-        assert.equal(decision, false, 'expected decision to be false');
+        assert.isFalse(decision, 'expected decision to be false');
         assert.deepEqual(tags, {}, 'expected tags to be empty');
 
         clock = sinon.useFakeTimers(initialDate + 1000);
         tags = {};
         decision = sampler.isSampled('operation', tags);
-        assert.equal(decision, true, 'expected decision to be true');
+        assert.isTrue(decision, 'expected decision to be true');
         assert.deepEqual(tags, {'sampler.type': 'ratelimiting', 'sampler.param': 10});
         clock.restore();
     });
@@ -59,10 +59,35 @@ describe ('RateLimitingSampler should', () => {
         let sampler = new RateLimitingSampler(0.1);
         sampler._rateLimiter._balance = 1;
 
-        assert.equal(sampler.isSampled('operation', {}), true, 'expected decision to be true');
+        assert.isTrue(sampler.isSampled('operation', {}), 'expected decision to be true');
 
         clock = sinon.useFakeTimers(initialDate + 10000);
-        assert.equal(sampler.isSampled('operation', {}), true, 'expected decision to be true');
+        assert.isTrue(sampler.isSampled('operation', {}), 'expected decision to be true');
         clock.restore();
+    });
+
+    it ('should update successfully', () => {
+        let initialDate = new Date(2011,9,1).getTime();
+        let clock = sinon.useFakeTimers(initialDate);
+        let sampler = new RateLimitingSampler(1.0);
+        sampler._rateLimiter._balance = 1;
+
+        assert.isTrue(sampler.isSampled('operation', {}), 'expected decision to be true');
+
+        assert.isFalse(sampler.update(1.0), 'updating using the same maxTracesPerSecond should return false');
+        assert.isTrue(sampler.update(2.0), 'updating using a different maxTracesPerSecond should return true');
+
+        clock = sinon.useFakeTimers(initialDate + 20000);
+        let tags = {};
+        assert.isTrue(sampler.isSampled('operation', tags), 'expected decision to be true');
+        assert.deepEqual(tags, {'sampler.type': 'ratelimiting', 'sampler.param': 2});
+        assert.isTrue(sampler.isSampled('operation', {}), 'expected decision to be true');
+        assert.isFalse(sampler.isSampled('operation', {}), 'expected decision to be false');
+        clock.restore();
+    });
+
+    it ('should throw error when updated with an incorrect value', () => {
+        let limiter = new RateLimitingSampler(2.0);
+        expect(() => { limiter.update(-2.0); }).to.throw('maxTracesPerSecond must be greater than 0.0.  Received -2');
     });
 });

--- a/test/samplers/ratelimiting_sampler_test.js
+++ b/test/samplers/ratelimiting_sampler_test.js
@@ -20,8 +20,7 @@ describe ('RateLimitingSampler should', () => {
     it('block after threshold is met', () => {
         let initialDate = new Date(2011,9,1).getTime();
         let clock = sinon.useFakeTimers(initialDate);
-        let sampler = new RateLimitingSampler(10);
-        sampler._rateLimiter._balance = 10;
+        let sampler = new RateLimitingSampler(10, 10);
         for (let i = 0; i < 10; i++) {
             assert.isTrue(sampler.isSampled('operation', {}), 'expected decision to be true');
         }
@@ -56,8 +55,7 @@ describe ('RateLimitingSampler should', () => {
     it ('work with maxCreditsPerSecond smaller than 1', () => {
         let initialDate = new Date(2011,9,1).getTime();
         let clock = sinon.useFakeTimers(initialDate);
-        let sampler = new RateLimitingSampler(0.1);
-        sampler._rateLimiter._balance = 1;
+        let sampler = new RateLimitingSampler(0.1, 1);
 
         assert.isTrue(sampler.isSampled('operation', {}), 'expected decision to be true');
 
@@ -69,8 +67,7 @@ describe ('RateLimitingSampler should', () => {
     it ('should update successfully', () => {
         let initialDate = new Date(2011,9,1).getTime();
         let clock = sinon.useFakeTimers(initialDate);
-        let sampler = new RateLimitingSampler(1.0);
-        sampler._rateLimiter._balance = 1;
+        let sampler = new RateLimitingSampler(1.0, 1);
 
         assert.isTrue(sampler.isSampled('operation', {}), 'expected decision to be true');
 

--- a/test/samplers/remote_sampler.js
+++ b/test/samplers/remote_sampler.js
@@ -129,6 +129,24 @@ describe('RemoteSampler', () => {
         remoteSampler._refreshSamplingStrategy();
     });
 
+    it('should update ratelimiting sampler', (done) => {
+        let rateLimitingSampler = new RateLimitingSampler(10);
+        remoteSampler._sampler = rateLimitingSampler;
+        let maxTracesPerSecond = 5;
+        remoteSampler._onSamplerUpdate = (s) => {
+            assert.strictEqual(rateLimitingSampler, remoteSampler._sampler);
+            assert.isOk(s.equal(new RateLimitingSampler(maxTracesPerSecond)));
+            done();
+        };
+        server.addStrategy('service1', {
+            strategyType: 'RATE_LIMITING',
+            rateLimitingSampling: {
+                maxTracesPerSecond: maxTracesPerSecond
+            }
+        });
+        remoteSampler._refreshSamplingStrategy();
+    });
+
     it('should set per-operation sampler', (done) => {
         server.addStrategy('service1', {
             strategyType: 'PROBABILISTIC',


### PR DESCRIPTION
The RateLimitingSampler is always recreated when the tracesPerSecond is updated. This forces the RateLimitingSampler to always sample on a sampling strategy update. If the number of instances for a service is in the thousands, this will generate thousands of sampled traces. This fix only updates the tracesPerSecond but keeps the balance intact to reduce the impact of a sampling strategy update.

Signed-off-by: Won Jun Jang <wjang@uber.com>