### PR TITLE
Adds support for the Zipkin HTTP B3 propagation format

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ An encoded channel is a channel wrapped in either a thrift encoder `TChannelAsTh
 or json encoder `TChannelAsJson`.  To wrap a server handler for thrift one can initialize
 a tchannel bridge, and wrap the encoded handler function with a `tracedHandler` decorator.
 The tchannel bridge takes an OpenTracing  tracer, and a context factory.  The context factory
-must be a function that returns a context with the methods 'getSpan', and 'setSpan' which retrieve 
+must be a function that returns a context with the methods 'getSpan', and 'setSpan' which retrieve
 and assign the span to the context respectively.
 
 ```javascript
@@ -159,6 +159,25 @@ span.setTag("jaeger-debug-id", "some-correlation-id");
 
 This allows using Jaeger UI to find the trace by this tag.
 
+### Zipkin Compatibility
+
+Support for [Zipkin's B3 Propagation HTTP
+headers](https://github.com/openzipkin/b3-propagation) is provided by the
+`ZipkinB3TextMapCodec`, which can be configured instead of the default
+`TextMapCodec`.
+
+The new codec can be used by registering it with a tracer instance as both an
+injector and an extractor:
+
+```
+let codec = new ZipkinB3TextMapCodec({ urlEncoding: true });
+
+tracer.registerInjector(opentracing.FORMAT_HTTP_HEADERS, codec);
+tracer.registerExtractor(opentracing.FORMAT_HTTP_HEADERS, codec);
+```
+
+This can prove useful when compatibility with existing Zipkin
+tracing/instrumentation is desired.
 
 ## License
 

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -28,6 +28,9 @@ module.exports = {
     NoopReporter:      require('./dist/src/reporters/noop_reporter.js').default,
     RemoteReporter:    require('./dist/src/reporters/remote_reporter.js').default,
 
+    TextMapCodec:         require('./dist/src/propagators/text_map_codec.js').default,
+    ZipkinB3TextMapCodec: require('./dist/src/propagators/zipkin_b3_text_map_codec.js').default,
+
     TestUtils:      require('./dist/src/test_util.js').default,
     TChannelBridge: require('./dist/src/tchannel_bridge.js').default,
     opentracing:    require('opentracing')

--- a/src/propagators/baggage.js
+++ b/src/propagators/baggage.js
@@ -1,0 +1,33 @@
+// @flow
+// Copyright (c) 2017 The Jaeger Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+
+/**
+* Parses a comma separated key=value pair list and add the reuslts to `baggage`.
+* E.g. "key1=value1, key2=value2, key3 = value3"
+* is converted to map[string]string { "key1" : "value1",
+*                                     "key2" : "value2",
+*                                     "key3" : "value3" }
+*
+* @param {any} baggage- the object container to accept the parsed key=value pairs
+* @param {string} values - the string value containing any key=value pairs
+* to parse
+*/
+export function parseCommaSeparatedBaggage(baggage: any, values: string): void {
+    values.split(',').forEach((keyVal) => {
+        let splitKeyVal: Array<string> = keyVal.trim().split('=');
+        if (splitKeyVal.length == 2) {
+            baggage[splitKeyVal[0]] = splitKeyVal[1];
+        }
+    });
+}

--- a/src/propagators/text_map_codec.js
+++ b/src/propagators/text_map_codec.js
@@ -16,6 +16,7 @@ import Metrics from '../metrics/metrics.js';
 import NoopMetricFactory from '../metrics/noop/metric_factory';
 import SpanContext from '../span_context.js';
 import Utils from '../util.js';
+import { parseCommaSeparatedBaggage } from '../propagators/baggage';
 
 export default class TextMapCodec {
     _urlEncoding: boolean;
@@ -76,7 +77,7 @@ export default class TextMapCodec {
                 } else if (lowerKey === constants.JAEGER_DEBUG_HEADER) {
                     debugId = this._decodeValue(carrier[key]);
                 } else if (lowerKey === constants.JAEGER_BAGGAGE_HEADER) {
-                    this._parseCommaSeparatedBaggage(baggage, this._decodeValue(carrier[key]));
+                    parseCommaSeparatedBaggage(baggage, this._decodeValue(carrier[key]));
                 } else if (Utils.startsWith(lowerKey, this._baggagePrefix)) {
                     let keyWithoutPrefix = key.substring(this._baggagePrefix.length);
                     baggage[keyWithoutPrefix] = this._decodeValue(carrier[key]);
@@ -100,19 +101,5 @@ export default class TextMapCodec {
                 carrier[`${this._baggagePrefix}${key}`] = value;
             }
         }
-    }
-
-    // Parse comma separated key=value pair list and add to baggage.
-    // E.g. "key1=value1, key2=value2, key3 = value3"
-    // is converted to map[string]string { "key1" : "value1",
-    //                                     "key2" : "value2",
-    //                                     "key3" : "value3" }
-    _parseCommaSeparatedBaggage(baggage: any, values: string): void {
-        values.split(',').forEach((keyVal) => {
-            let splitKeyVal: Array<string> = keyVal.trim().split('=');
-            if (splitKeyVal.length == 2) {
-                baggage[splitKeyVal[0]] = splitKeyVal[1];
-            }
-        });
     }
 }

--- a/src/propagators/zipkin_b3_text_map_codec.js
+++ b/src/propagators/zipkin_b3_text_map_codec.js
@@ -21,7 +21,7 @@ const ZIPKIN_PARENTSPAN_HEADER = 'x-b3-parentspanid';
 const ZIPKIN_SPAN_HEADER = 'x-b3-spanid';
 const ZIPKIN_TRACE_HEADER = 'x-b3-traceid';
 const ZIPKIN_SAMPLED_HEADER = 'x-b3-sampled';
-const ZIPKIN_DEBUG_HEADER = 'x-b3-flags';
+const ZIPKIN_FLAGS_HEADER = 'x-b3-flags';
 
 export default class ZipkinB3TextMapCodec {
     _urlEncoding: boolean;
@@ -82,7 +82,7 @@ export default class ZipkinB3TextMapCodec {
                     case ZIPKIN_SAMPLED_HEADER:
                         spanContext.flags = spanContext.flags | constants.SAMPLED_MASK;
                         break;
-                    case ZIPKIN_DEBUG_HEADER:
+                    case ZIPKIN_FLAGS_HEADER:
                         // "debug implies sampled"
                         // https://github.com/openzipkin/b3-propagation
                         spanContext.flags = spanContext.flags | constants.SAMPLED_MASK | constants.DEBUG_MASK;
@@ -115,7 +115,7 @@ export default class ZipkinB3TextMapCodec {
         // https://github.com/openzipkin/b3-propagation
 
         if (spanContext.isDebug()) {
-           carrier[ZIPKIN_DEBUG_HEADER] = '1';
+           carrier[ZIPKIN_FLAGS_HEADER] = '1';
         } else {
             if (spanContext.isSampled()) {
                 carrier[ZIPKIN_SAMPLED_HEADER] = '1';

--- a/src/propagators/zipkin_b3_text_map_codec.js
+++ b/src/propagators/zipkin_b3_text_map_codec.js
@@ -1,0 +1,157 @@
+// @flow
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import * as constants from '../constants.js';
+import Metrics from '../metrics/metrics.js';
+import NoopMetricFactory from '../metrics/noop/metric_factory';
+import SpanContext from '../span_context.js';
+import Utils from '../util.js';
+
+const ZIPKIN_PARENTSPAN_HEADER = 'x-b3-parentspanid';
+const ZIPKIN_SPAN_HEADER = 'x-b3-spanid';
+const ZIPKIN_TRACE_HEADER = 'x-b3-traceid';
+const ZIPKIN_SAMPLED_HEADER = 'x-b3-sampled';
+const ZIPKIN_DEBUG_HEADER = 'x-b3-flags';
+
+export default class ZipkinB3TextMapCodec {
+    _urlEncoding: boolean;
+    _baggagePrefix: string;
+    _metrics: any;
+
+    constructor(options: any = {}) {
+        this._urlEncoding = !!options.urlEncoding;
+        this._baggagePrefix = options.baggagePrefix || constants.TRACER_BAGGAGE_HEADER_PREFIX;
+        this._baggagePrefix = this._baggagePrefix.toLowerCase();
+        this._metrics = options.metrics || new Metrics(new NoopMetricFactory());
+    }
+
+    _encodeValue(value: string): string {
+        if (this._urlEncoding) {
+            return encodeURIComponent(value);
+        }
+
+        return value;
+    }
+
+    _decodeValue(value: string): string {
+        // only use url-decoding if there are meta-characters '%'
+        if (this._urlEncoding && value.indexOf('%') > -1) {
+            return this._decodeURIValue(value);
+        }
+
+        return value;
+    }
+
+    _decodeURIValue(value: string): string {
+        // unfortunately, decodeURIComponent() can throw 'URIError: URI malformed' on bad strings
+        try {
+            return decodeURIComponent(value);
+        } catch (e) {
+            return value;
+        }
+    }
+
+    extract(carrier: any): ?SpanContext {
+        let spanContext = new SpanContext();
+        let baggage = {};
+
+        for (let key in carrier) {
+            if (carrier.hasOwnProperty(key)) {
+                let lowerKey = key.toLowerCase();
+
+                switch (lowerKey) {
+                    case ZIPKIN_PARENTSPAN_HEADER:
+                        spanContext.parentId = this._decodeValue(carrier[ZIPKIN_PARENTSPAN_HEADER]);
+                        break;
+                    case ZIPKIN_SPAN_HEADER:
+                        spanContext.spanId = this._decodeValue(carrier[ZIPKIN_SPAN_HEADER]);
+                        break;
+                    case ZIPKIN_TRACE_HEADER:
+                        spanContext.traceId = this._decodeValue(carrier[ZIPKIN_TRACE_HEADER]);
+                        break;
+                    case ZIPKIN_SAMPLED_HEADER:
+                        spanContext.flags = spanContext.flags | constants.SAMPLED_MASK;
+                        break;
+                    case ZIPKIN_DEBUG_HEADER:
+                        // "debug implies sampled"
+                        // https://github.com/openzipkin/b3-propagation
+                        spanContext.flags = spanContext.flags | constants.SAMPLED_MASK | constants.DEBUG_MASK;
+                        break;
+                    case constants.JAEGER_DEBUG_HEADER:
+                        spanContext.debugId = this._decodeValue(carrier[constants.JAEGER_DEBUG_HEADER]);
+                        break;
+                    case constants.JAEGER_BAGGAGE_HEADER:
+                        this._parseCommaSeparatedBaggage(baggage, this._decodeValue(carrier[key]));
+                        break;
+                    default:
+                        if (Utils.startsWith(lowerKey, this._baggagePrefix)) {
+                            let keyWithoutPrefix = key.substring(this._baggagePrefix.length);
+                            baggage[keyWithoutPrefix] = this._decodeValue(carrier[key]);
+                        }
+                }
+            }
+        }
+
+        spanContext.baggage = baggage;
+        return spanContext;
+    }
+
+    inject(spanContext: SpanContext, carrier: any): void {
+        carrier[ZIPKIN_TRACE_HEADER] = spanContext.traceIdStr;
+        carrier[ZIPKIN_PARENTSPAN_HEADER] = spanContext.parentIdStr;
+        carrier[ZIPKIN_SPAN_HEADER] = spanContext.spanIdStr;
+
+        // > Since Debug implies Sampled, so don't also send "X-B3-Sampled: 1"
+        // https://github.com/openzipkin/b3-propagation
+
+        if (spanContext.isDebug()) {
+           carrier[ZIPKIN_DEBUG_HEADER] = '1';
+        } else {
+            if (spanContext.isSampled()) {
+                carrier[ZIPKIN_SAMPLED_HEADER] = '1';
+            } else {
+                carrier[ZIPKIN_SAMPLED_HEADER] = '0';
+            }
+        }
+
+        let baggage = spanContext.baggage;
+        for (let key in baggage) {
+            if (baggage.hasOwnProperty(key)) {
+                let value = this._encodeValue(spanContext.baggage[key]);
+                carrier[`${this._baggagePrefix}${key}`] = value;
+            }
+        }
+    }
+
+    // Parse comma separated key=value pair list and add to baggage.
+    // E.g. "key1=value1, key2=value2, key3 = value3"
+    // is converted to map[string]string { "key1" : "value1",
+    //                                     "key2" : "value2",
+    //                                     "key3" : "value3" }
+    _parseCommaSeparatedBaggage(baggage: any, values: string): void {
+        values.split(',').forEach((keyVal) => {
+            let splitKeyVal: Array<string> = keyVal.trim().split('=');
+            if (splitKeyVal.length == 2) {
+                baggage[splitKeyVal[0]] = splitKeyVal[1];
+            }
+        });
+    }
+}

--- a/src/propagators/zipkin_b3_text_map_codec.js
+++ b/src/propagators/zipkin_b3_text_map_codec.js
@@ -54,7 +54,16 @@ export default class ZipkinB3TextMapCodec {
     }
 
     _isValidZipkinId(value: string): boolean {
-        // Validates a zipkin trace/spanID by attempting to parse it as a string of hex digits.
+        // Validates a zipkin trace/spanID by attempting to parse it as a
+        // string of hex digits. This "validation" is not entirely rigorous,
+        // but equivalent to what is performed in the TextMapCodec.
+        //
+        // Note: due to the way parseInt works, this does not guarantee that
+        // the string is composed *entirely* of hex digits.
+        //
+        // > If parseInt encounters a character that is not a numeral in the
+        // > specified radix, it ignores it and all succeeding characters and
+        // > returns the integer value parsed up to that point.
         //
         // Note: The Number type in JS cannot represent the full range of 64bit
         // unsigned ints, so using parseInt() on strings representing 64bit hex
@@ -68,8 +77,7 @@ export default class ZipkinB3TextMapCodec {
             return true
         }
 
-        let v = parseInt(value, 16);
-        return !isNaN(v) && v.toString(16) === value;
+        return !isNaN(parseInt(value, 16));
     }
 
     _decodeURIValue(value: string): string {

--- a/src/propagators/zipkin_b3_text_map_codec.js
+++ b/src/propagators/zipkin_b3_text_map_codec.js
@@ -1,23 +1,15 @@
 // @flow
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 The Jaeger Authors
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
 //
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
+// http://www.apache.org/licenses/LICENSE-2.0
 //
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
 
 import * as constants from '../constants.js';
 import Metrics from '../metrics/metrics.js';

--- a/test/propagators.js
+++ b/test/propagators.js
@@ -11,7 +11,9 @@
 // the License.
 
 import {assert} from 'chai';
+import * as constants from '../src/constants';
 import TextMapCodec from '../src/propagators/text_map_codec';
+import ZipkinB3TextMapCodec from '../src/propagators/zipkin_b3_text_map_codec';
 import SpanContext from '../src/span_context';
 
 describe ('TextMapCodec', () => {
@@ -50,5 +52,93 @@ describe ('TextMapCodec', () => {
         };
         let ctx = codec.extract(carrier);
         assert.deepEqual(ctx.baggage, { 'some-key': 'some-value' });
+    });
+});
+
+describe ('ZipkinB3TextMapCodec', () => {
+    it('correctly extract the zipkin headers from a span context', () => {
+        let codec = new ZipkinB3TextMapCodec({ urlEncoding: true });
+
+        let carrier = {
+            'x-b3-parentspanid': 'some-parent',
+            'x-b3-spanid': 'some-span',
+            'x-b3-traceid': 'some-trace',
+            'x-b3-sampled': '1',
+            'x-b3-flags': '1',
+            'foo': 'bar'
+        };
+
+        let ctx = codec.extract(carrier);
+        assert.equal(ctx.parentId, 'some-parent');
+        assert.equal(ctx.spanId, 'some-span');
+        assert.equal(ctx.traceId, 'some-trace');
+        assert.equal(ctx.isSampled(), true);
+        assert.equal(ctx.isDebug(), true);
+    });
+
+    it('correctly inject the zipkin headers into a span context', () => {
+        let codec = new ZipkinB3TextMapCodec({ urlEncoding: true });
+        let carrier = {};
+
+        let ctx = SpanContext.withStringIds('some-trace', 'some-span', 'some-parent');
+        ctx.flags = constants.DEBUG_MASK | constants.SAMPLED_MASK;
+
+        codec.inject(ctx, carrier);
+        assert.equal(carrier['x-b3-traceid'], 'some-trace');
+        assert.equal(carrier['x-b3-spanid'], 'some-span');
+        assert.equal(carrier['x-b3-parentspanid'], 'some-parent');
+        assert.equal(carrier['x-b3-flags'], '1');
+
+        // > Since Debug implies Sampled, so don't also send "X-B3-Sampled: 1"
+        // https://github.com/openzipkin/b3-propagation
+        assert.isUndefined(carrier['x-b3-sampled']);
+    });
+
+    it('should not URL-decode value that has no % meta-characters', () => {
+        let codec = new ZipkinB3TextMapCodec({ urlEncoding: true });
+        codec._decodeURIValue = (value: string) => {
+            throw new URIError('fake error');
+        };
+        assert.strictEqual(codec._decodeValue('abc'), 'abc');
+    });
+
+    it('should not throw exception on bad URL-encoded values', () => {
+        let codec = new ZipkinB3TextMapCodec({ urlEncoding: true });
+        // this string throws exception when passed to decodeURIComponent
+        assert.strictEqual(codec._decodeValue('%EA'), '%EA');
+    });
+
+    it('should decode baggage', () => {
+        let codec = new ZipkinB3TextMapCodec({
+            urlEncoding: true,
+            contextKey: 'trace-context',
+            baggagePrefix: 'baggage-'
+        });
+        let carrier = {
+            'x-b3-parentspanid': 'some-parent',
+            'x-b3-spanid': 'some-span',
+            'x-b3-traceid': 'some-trace',
+            'baggage-some-key': 'some-value',
+            'garbage-in': 'garbage-out'
+        };
+        let ctx = codec.extract(carrier);
+        assert.deepEqual(ctx.baggage, { 'some-key': 'some-value' });
+    });
+
+    it('should encode baggage', () => {
+        let codec = new ZipkinB3TextMapCodec({
+            urlEncoding: true,
+            contextKey: 'trace-context',
+            baggagePrefix: 'baggage-'
+        });
+        let carrier = {};
+
+        let ctx = SpanContext.withStringIds('some-trace', 'some-span', 'some-parent');
+        ctx = ctx.withBaggageItem('some-key', 'some-value');
+        ctx = ctx.withBaggageItem('another-key', 'another-value');
+
+        codec.inject(ctx, carrier);
+        assert.equal(carrier['baggage-some-key'], 'some-value');
+        assert.equal(carrier['baggage-another-key'], 'another-value');
     });
 });

--- a/test/propagators.js
+++ b/test/propagators.js
@@ -40,8 +40,8 @@ describe ('TextMapCodec', () => {
     });
 
     it('should decode baggage', () => {
-        let codec = new TextMapCodec({ 
-            urlEncoding: true, 
+        let codec = new TextMapCodec({
+            urlEncoding: true,
             contextKey: 'trace-context',
             baggagePrefix: 'baggage-'
         });

--- a/test/zipkin_b3_text_map_codec.js
+++ b/test/zipkin_b3_text_map_codec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 The Jaeger Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at

--- a/test/zipkin_b3_text_map_codec.js
+++ b/test/zipkin_b3_text_map_codec.js
@@ -64,19 +64,19 @@ describe('Zipkin B3 Text Map Codec should', () => {
 
         let testCases = [
             {
-                'x-b3-traceid': 'bad-value',
+                'x-b3-traceid': 'zzzzzz',
                 'x-b3-spanid': '123abc',
                 'x-b3-parentspanid': '456def'
             },
             {
                 'x-b3-traceid': '123abc',
-                'x-b3-spanid': 'bad-value',
+                'x-b3-spanid': 'zzzzzz',
                 'x-b3-parentspanid': '456def'
             },
             {
                 'x-b3-traceid': '123abc',
                 'x-b3-spanid': '456def',
-                'x-b3-parentspanid': 'bad-value'
+                'x-b3-parentspanid': 'zzzzz'
             }
         ];
 

--- a/test/zipkin_b3_text_map_codec.js
+++ b/test/zipkin_b3_text_map_codec.js
@@ -1,0 +1,118 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+import {assert} from 'chai';
+import * as constants from '../src/constants.js';
+import ConstSampler from '../src/samplers/const_sampler.js';
+import InMemoryReporter from '../src/reporters/in_memory_reporter.js';
+import opentracing from 'opentracing';
+import Tracer from '../src/tracer.js';
+import Metrics from '../src/metrics/metrics.js';
+import LocalMetricFactory from './lib/metrics/local/metric_factory.js';
+import LocalBackend from './lib/metrics/local/backend.js';
+import SpanContext from '../src/span_context.js';
+import ZipkinB3TextMapCodec from '../src/propagators/zipkin_b3_text_map_codec.js';
+
+describe('Zipkin B3 Text Map Codec should', () => {
+
+    let tracer, codec;
+
+    beforeEach(() => {
+        let metrics = new Metrics(new LocalMetricFactory());
+        tracer = new Tracer(
+            'test-tracer',
+            new InMemoryReporter(),
+            new ConstSampler(false), {
+                metrics: metrics
+            }
+        );
+
+        codec = new ZipkinB3TextMapCodec({
+            urlEncoding: true,
+            metrics: metrics,
+        });
+
+        tracer.registerInjector(opentracing.FORMAT_HTTP_HEADERS, codec);
+        tracer.registerExtractor(opentracing.FORMAT_HTTP_HEADERS, codec);
+    });
+
+    afterEach(() => {
+        tracer.close();
+    });
+
+    it ('set the sampled flag when the zipkin sampled header is received', () => {
+        let headers = {
+            'x-b3-sampled': '1'
+        };
+
+        let context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
+        assert.isOk(context.isSampled());
+        assert.isNotOk(context.isDebug());
+    });
+
+    it ('set the debug and sampled flags with the zipkin flags header is recieved', () => {
+        let headers = {
+            'x-b3-flags': '1'
+        };
+
+        let context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
+        assert.isOk(context.isSampled());
+        assert.isOk(context.isDebug());
+    });
+
+    it ('should set the sampled header to "1" if sampling', () => {
+        let headers = {};
+
+        let ctx = SpanContext.withStringIds('some-trace', 'some-span', 'some-parent');
+        codec.inject(ctx, headers);
+
+        assert.isUndefined(headers['x-b3-flags']);
+        assert.equal(headers['x-b3-sampled'], '0');
+    });
+
+    it ('should set the sampled header to "1" if sampling', () => {
+        let headers = {};
+
+        let ctx = SpanContext.withStringIds('some-trace', 'some-span', 'some-parent');
+        ctx.flags = constants.SAMPLED_MASK;
+
+        codec.inject(ctx, headers);
+
+        assert.isUndefined(headers['x-b3-flags']);
+        assert.isOk(headers['x-b3-sampled']);
+    });
+
+    it ('should not send the sampled header if debug', () => {
+        let headers = {};
+
+        let ctx = SpanContext.withStringIds('some-trace', 'some-span', 'some-parent');
+        ctx.flags = constants.DEBUG_MASK
+
+        codec.inject(ctx, headers);
+
+        assert.equal(headers['x-b3-flags'], '1');
+        // > Since Debug implies Sampled, so don't also send "X-B3-Sampled: 1"
+        // https://github.com/openzipkin/b3-propagation
+        assert.isUndefined(headers['x-b3-sampled']);
+    });
+
+    it ('supports the use of the baggage headers', () => {
+        let headers = {};
+        headers[constants.TRACER_BAGGAGE_HEADER_PREFIX + 'a-key'] = 'a-value';
+        headers[constants.JAEGER_BAGGAGE_HEADER] = 'some-key=some-value, another-key=another-value';
+
+        let context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
+        assert.equal(context.baggage['a-key'], 'a-value');
+        assert.equal(context.baggage['some-key'], 'some-value');
+        assert.equal(context.baggage['another-key'], 'another-value');
+    });
+});


### PR DESCRIPTION
This PR addresses #165 by adding a new text map codec.  

The new codec (named `ZipkinB3TextMapCodec`) injects and extracts the relevant `X-B3-*` headers used by zipkin, according to [the zipkin spec](https://github.com/openzipkin/b3-propagation).

The new codec can be used by registering it with a tracer instance as both an injector and an extractor:

```
let codec = new ZipkinB3TextMapCodec({                                                            
    urlEncoding: true                                                                          
}); 

tracer.registerInjector(opentracing.FORMAT_HTTP_HEADERS, codec);                                  
tracer.registerExtractor(opentracing.FORMAT_HTTP_HEADERS, codec);
```

In order to accomodate this functionality, I added this new codec (as well as the existing `TextMapCodec` ) to the exported entrypoint of the lib.  If this is not a preferred change to the lib, please let me know.

Baggage handling was left unchanged from the way it's currently done in the `TextMapCodec`.

If a `README` is desired for this new Zipkin support (as is done in [the Jaeger Go client](https://github.com/jaegertracing/jaeger-client-go/tree/master/zipkin)), I'd be happy to add one.

Thanks in advance for feedback on the PR!