### PR TITLE
Preparing release 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changes by Version
 ==================
 
+3.7.0 (2017-11-21)
+------------------
+
+- Add support for Zipkin B3 header propagation (#175)
+
+
 3.6.0 (2017-11-13)
 ------------------
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaeger-client",
-  "version": "3.6.1dev0",
+  "version": "3.7.0",
   "description": "Jaeger binding for OpenTracing Node",
   "license": "Apache-2.0",
   "keywords": [],


### PR DESCRIPTION
[Per the release instructions](https://github.com/jaegertracing/jaeger-client-node/blob/master/RELEASE.md), this PR prepares for release 3.7.0.  This is a minor version increment, to add the changes contained in #175.