### PR TITLE
Remove "babel-node-debug" dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "babel-cli": "^6.11.4",
     "babel-istanbul": "^0.11.0",
-    "babel-node-debug": "^2.0.0",
     "babel-plugin-transform-class-properties": "^6.11.5",
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-preset-es2015": "^6.13.2",


### PR DESCRIPTION
Remove dev dependency that is no longer maintained
Signed-off-by: Kara de la Marck <karadelamarck@gmail.com>
Cf. #183