### PR TITLE
Remove test-ci script

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "flow": "flow",
     "lint": "eslint $(ls src/ | grep '.js$') && echo '# linter passed' && npm run check-license",
     "test": "make test",
-    "test-ci": "npm run test && npm run lint",
     "test-all": "npm run test-core && npm run test-samplers && npm run test-crossdock && npm run test-baggage",
     "test-core": "mocha --compilers js:babel-core/register test",
     "test-samplers": "mocha --compilers js:babel-core/register test/samplers",


### PR DESCRIPTION
`test-ci` script is possibly redundant. It runs `npm run test && npm run lint`; however, `npm run test` runs `make test`, which runs `npm run lint`. Thus, running `npm run lint` again is possibly redundant, hence this whole script is redundant, and one could just run `npm run test`.

Signed-off-by: Kara de la Marck <karadelamarck@gmail.com>