### PR TITLE
Throw error if serviceName is not provided

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
 - if [ "$CROSSDOCK" = "1" ]; then make crossdock-fresh ; fi
 
 after_failure:
-- timeout 5 if [ "$CROSSDOCK" = "1" ]; then make crossdock-fresh ; fi
+- if [ "$CROSSDOCK" = "1" ]; then timeout 5 make crossdock-logs ; fi
 
 after_success:
 - export REPO=jaegertracing/xdock-node

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -153,6 +153,8 @@ export default class Configuration {
         }
         if (config.disable) {
             return new opentracing.Tracer();
+        } else if (!config.serviceName) {
+            throw new Error(`config.serviceName must be provided`);
         } else {
             if (config.sampler) {
                 sampler = Configuration._getSampler(config);
@@ -171,10 +173,6 @@ export default class Configuration {
             options.logger.info(
                 `Initializing Jaeger Tracer with ${reporter.name()} and ${sampler.name()}`
             );
-        }
-
-        if (config.serviceName === undefined || config.serviceName === null) {
-            throw new Error(`config.serviceName must be provided`);
         }
 
         return new Tracer(

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -153,20 +153,19 @@ export default class Configuration {
         }
         if (config.disable) {
             return new opentracing.Tracer();
-        } else if (!config.serviceName) {
+        }
+        if (!config.serviceName) {
             throw new Error(`config.serviceName must be provided`);
+        }
+        if (config.sampler) {
+            sampler = Configuration._getSampler(config);
         } else {
-            if (config.sampler) {
-                sampler = Configuration._getSampler(config);
-            } else {
-                sampler = new RemoteSampler(config.serviceName, options);
-            }
-
-            if (!options.reporter) {
-                reporter = Configuration._getReporter(config, options);
-            } else {
-                reporter = options.reporter;
-            }
+            sampler = new RemoteSampler(config.serviceName, options);
+        }
+        if (!options.reporter) {
+            reporter = Configuration._getReporter(config, options);
+        } else {
+            reporter = options.reporter;
         }
 
         if (options.logger) {

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -173,6 +173,10 @@ export default class Configuration {
             );
         }
 
+        if (config.serviceName === undefined || config.serviceName === null) {
+            throw new Error(`config.serviceName must be provided`);
+        }
+
         return new Tracer(
             config.serviceName,
             reporter,

--- a/test/init_tracer.js
+++ b/test/init_tracer.js
@@ -34,7 +34,15 @@ describe('initTracer', () => {
     });
 
     it ('should throw error on invalid serviceName', () => {
-        expect(() => { initTracer({}); }).to.throw('config.serviceName must be provided');
+        let configs = [
+            { serviceName: ''},
+            { serviceName: null},
+            {},
+        ];
+
+        _.each(configs, (config) => {
+            expect(() => { initTracer(config); }).to.throw('config.serviceName must be provided');
+        });
     });
 
     it ('should initialize normal tracer when only service name given', () => {

--- a/test/init_tracer.js
+++ b/test/init_tracer.js
@@ -33,6 +33,10 @@ describe('initTracer', () => {
         expect(tracer).to.be.an.instanceof(opentracing.Tracer);
     });
 
+    it ('should throw error on invalid serviceName', () => {
+        expect(() => { initTracer({}); }).to.throw('config.serviceName must be provided');
+    });
+
     it ('should initialize normal tracer when only service name given', () => {
         let config = {
             serviceName: 'test-service'
@@ -44,10 +48,10 @@ describe('initTracer', () => {
     });
 
     it ('should initialize proper samplers', () => {
-        var config = {
+        let config = {
             serviceName: 'test-service'
         };
-        var options = [
+        let options = [
             { type: 'const', param: 1, expectedType: ConstSampler, expectedParam: 1 },
             { type: 'ratelimiting', param: 2, expectedType: RateLimitingSampler, expectedParam: 2 },
             { type: 'probabilistic', param: 0.5, expectedType: ProbabilisticSampler, expectedParam: 0.5 },
@@ -69,10 +73,10 @@ describe('initTracer', () => {
     });
 
     it ('should throw error on sampler incorrect type', () => {
-        var config = {
+        let config = {
             serviceName: 'test-service'
         };
-        var options = [
+        let options = [
             { type: 'const', param: 'bad-value' },
             { type: 'ratelimiting', param: 'bad-value' },
             { type: 'probabilistic', param: 'bad-value' },
@@ -108,7 +112,7 @@ describe('initTracer', () => {
                 agentPort: 4939,
                 flushIntervalMs: 2000
             }
-        }
+        };
         let tracer = initTracer(config);
 
         expect(tracer._reporter).to.be.an.instanceof(CompositeReporter);
@@ -127,10 +131,10 @@ describe('initTracer', () => {
     });
 
     it ('should pass options to tracer', () => {
-        var logger = {
+        let logger = {
             'info': function info(msg){}
         };
-        var metrics = {
+        let metrics = {
             'createCounter': function createCounter() { return {}; },
             'createGauge': function createGauge() { return {}; },
             'createTimer': function createTimer() { return {}; },


### PR DESCRIPTION
This was the cause of https://github.com/jaegertracing/jaeger-client-node/issues/181

Since serviceName is not provided, the jaeger batch to thrift conversion fails. 