### PR TITLE
Fix second npm install in before_script travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_script:
 - nvm use $TEST_NODE_VERSION
 - node --version
 - rm -rf ./node_modules package-lock.json
-- npm install
+- npm install --production
 
 script:
 - if [ "$CROSSDOCK" != "1" ]; then make test-without-build; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,8 @@ before_script:
 - make build-node
 - nvm use $TEST_NODE_VERSION
 - node --version
-- rm -rf ./node_modules package-lock.json
-- npm install --production
+- rm -f package-lock.json
+- npm install --only=prod
 
 script:
 - if [ "$CROSSDOCK" != "1" ]; then make test-without-build; fi


### PR DESCRIPTION
Second npm install should now not install devDependencies.

Signed-off-by: Kara de la Marck <karadelamarck@gmail.com>