### PR TITLE
fix `this._batch` is undefined when start

### DIFF
--- a/src/reporters/udp_sender.js
+++ b/src/reporters/udp_sender.js
@@ -119,7 +119,7 @@ export default class UDPSender {
     }
 
     flush(): SenderResponse {
-        let numSpans: number = this._batch.spans.length;
+        let numSpans: number = this._batch ? this._batch.spans.length : 0;
         if (numSpans == 0) {
             return {err: false, numSpans: 0}
         }


### PR DESCRIPTION
when start a Node.js application, wait a few seconds, it will throw:
```
       let numSpans: number = this._batch.spans.length;
                                           ^
TypeError: Cannot read property 'spans' of undefined
    at UDPSender.flush (/xxx/node_modules/jaeger-client/src/reporters/udp_sender.js:117:44)
```