### PR TITLE
Exposing formats, to make it easy to get them to inject span_context

### DIFF
--- a/entrypoint.js
+++ b/entrypoint.js
@@ -17,6 +17,7 @@ module.exports = {
   SpanContext: require('./dist/src/span_context.js').default,
   Span: require('./dist/src/span.js').default,
   Tracer: require('./dist/src/tracer.js').default,
+  Formats: require('./dist/src/formats.js'),
 
   ConstSampler: require('./dist/src/samplers/const_sampler.js').default,
   ProbabilisticSampler: require('./dist/src/samplers/probabilistic_sampler.js').default,

--- a/src/formats.js
+++ b/src/formats.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+import opentracing from 'opentracing';
+
+//FORMAT_BINARY format represents SpanContexts in an opaque binary carrier.
+export const FORMAT_BINARY = opentracing.FORMAT_BINARY;
+
+//FORMAT_TEXT_MAP format represents SpanContexts using a string->string map (backed by a Javascript Object) as a carrier.
+export const FORMAT_TEXT_MAP = opentracing.FORMAT_TEXT_MAP;
+
+//FORMAT_HTTP_HEADERS format represents SpanContexts using a character-restricted string->string map (backed by a Javascript Object) as a carrier.
+export const FORMAT_HTTP_HEADERS = opentracing.FORMAT_HTTP_HEADERS;

--- a/test/formats.js
+++ b/test/formats.js
@@ -1,0 +1,29 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+import { assert, expect } from 'chai';
+import { FORMAT_BINARY, FORMAT_TEXT_MAP, FORMAT_HTTP_HEADERS } from '../src/formats';
+import opentracing from 'opentracing';
+
+describe('formats', () => {
+  it('FORMAT_BINARY should be opentracing constant FORMAT_BINARY', () => {
+    expect(FORMAT_BINARY).to.be.equal(opentracing.FORMAT_BINARY);
+  });
+
+  it('FORMAT_TEXT_MAP should be opentracing constant FORMAT_TEXT_MAP', () => {
+    expect(FORMAT_TEXT_MAP).to.equal(opentracing.FORMAT_TEXT_MAP);
+  });
+
+  it('FORMAT_HTTP_HEADERS should be opentracing constant FORMAT_HTTP_HEADERS', () => {
+    expect(FORMAT_HTTP_HEADERS).to.equal(opentracing.FORMAT_HTTP_HEADERS);
+  });
+});


### PR DESCRIPTION
Today we can not get formats from the library.
I expose the formats to make it easy import formats const string.