### PR TITLE
Use callbacks in UDPSender and remoteReporter

### DIFF
--- a/src/reporters/composite_reporter.js
+++ b/src/reporters/composite_reporter.js
@@ -35,9 +35,7 @@ export default class CompositeReporter {
     return () => {
       count++;
       if (count >= this._reporters.length) {
-        if (callback) {
-          callback();
-        }
+        if (callback) callback();
       }
     };
   }

--- a/src/reporters/remote_reporter.js
+++ b/src/reporters/remote_reporter.js
@@ -65,9 +65,7 @@ export default class RemoteReporter {
       } else {
         this._metrics.reporterSuccess.increment(response.numSpans);
       }
-      if (callback) {
-        callback();
-      }
+      if (callback) callback();
     });
   }
 
@@ -75,9 +73,7 @@ export default class RemoteReporter {
     clearInterval(this._intervalHandle);
     this.flush(() => {
       this._sender.close();
-      if (callback) {
-        callback();
-      }
+      if (callback) callback();
     });
   }
 

--- a/src/reporters/udp_sender.js
+++ b/src/reporters/udp_sender.js
@@ -91,15 +91,21 @@ export default class UDPSender {
     this._maxSpanBytes = this._maxPacketSize - this._emitSpanBatchOverhead;
   }
 
-  append(span: any): SenderResponse {
+  append(span: any, callback: ?Function): void {
     let lengthResult: LengthResult = this._calcSpanSize(span);
     if (lengthResult.err) {
       this._logger.error(`error converting span to Thrift: ${lengthResult.err}`);
-      return { err: true, numSpans: 1 };
+      if (callback) {
+        callback({ err: true, numSpans: 1 });
+      }
+      return;
     }
     let spanSize: number = lengthResult.length;
     if (spanSize > this._maxSpanBytes) {
-      return { err: true, numSpans: 1 };
+      if (callback) {
+        callback({ err: true, numSpans: 1 });
+      }
+      return;
     }
 
     if (this._totalSpanBytes + spanSize <= this._maxSpanBytes) {
@@ -107,21 +113,30 @@ export default class UDPSender {
       this._totalSpanBytes += spanSize;
       if (this._totalSpanBytes < this._maxSpanBytes) {
         // still have space in the buffer, don't flush it yet
-        return { err: false, numSpans: 0 };
+        if (callback) {
+          callback({ err: false, numSpans: 0 });
+        }
+        return;
       }
-      return this.flush();
+      this.flush(callback);
+      return;
     }
-
-    let flushResponse: SenderResponse = this.flush();
-    this._batch.spans.push(span);
-    this._totalSpanBytes = spanSize;
-    return flushResponse;
+    this.flush(result => {
+      this._batch.spans.push(span);
+      this._totalSpanBytes += spanSize;
+      // if (callback) {
+      //   callback(result);
+      // }
+    });
   }
 
-  flush(): SenderResponse {
+  flush(callback: ?Function): void {
     let numSpans: number = this._batch.spans.length;
     if (numSpans == 0) {
-      return { err: false, numSpans: 0 };
+      if (callback) {
+        callback({ err: false, numSpans: 0 });
+      }
+      return;
     }
 
     let bufferLen = this._totalSpanBytes + this._emitSpanBatchOverhead;
@@ -131,24 +146,29 @@ export default class UDPSender {
       thriftBuffer,
       0
     );
+    this._reset();
 
     if (writeResult.err) {
       this._logger.error(`error writing Thrift object: ${writeResult.err}`);
-      return { err: true, numSpans: numSpans };
+      if (callback) {
+        callback({ err: true, numSpans: numSpans });
+      }
+      return;
     }
 
     // Having the error callback here does not prevent uncaught exception from being thrown,
     // that's why in the constructor we also add a general on('error') handler.
+    // this._reset();
     this._client.send(thriftBuffer, 0, thriftBuffer.length, this._port, this._host, (err, sent) => {
       if (err) {
         this._logger.error(
           `error sending spans over UDP: ${err}, packet size: ${writeResult.offset}, bytes sent: ${sent}`
         );
       }
+      if (callback) {
+        callback({ err: err !== 0, numSpans: numSpans });
+      }
     });
-    this._reset();
-
-    return { err: false, numSpans: numSpans };
   }
 
   _convertBatchToThriftMessage() {

--- a/src/reporters/udp_sender.js
+++ b/src/reporters/udp_sender.js
@@ -124,9 +124,6 @@ export default class UDPSender {
     this.flush(result => {
       this._batch.spans.push(span);
       this._totalSpanBytes += spanSize;
-      // if (callback) {
-      //   callback(result);
-      // }
     });
   }
 
@@ -158,7 +155,6 @@ export default class UDPSender {
 
     // Having the error callback here does not prevent uncaught exception from being thrown,
     // that's why in the constructor we also add a general on('error') handler.
-    // this._reset();
     this._client.send(thriftBuffer, 0, thriftBuffer.length, this._port, this._host, (err, sent) => {
       if (err) {
         this._logger.error(

--- a/test/all_reporters.js
+++ b/test/all_reporters.js
@@ -65,10 +65,11 @@ describe('All Reporters should', () => {
   ];
 
   _.each(closeOptions, o => {
-    it('calls to close execute callback correctly', () => {
+    it('calls to close execute callback correctly', done => {
       let reporter = new CompositeReporter(reporters);
 
       reporter.close(o.callback);
+      done();
 
       assert.isOk(o.predicate(o.callback));
     });

--- a/test/remote_reporter.js
+++ b/test/remote_reporter.js
@@ -52,7 +52,7 @@ describe('Composite and Remote Reporter should', () => {
     reporter.close(callback);
   });
 
-  it('report span, and flush', () => {
+  it('report span, and flush', done => {
     let span = tracer.startSpan('operation-name');
 
     // add duration to span, and report it
@@ -60,6 +60,7 @@ describe('Composite and Remote Reporter should', () => {
     assert.equal(sender._batch.spans.length, 1);
 
     reporter.flush();
+    done();
     assert.equal(sender._batch.spans.length, 0);
     assert.isOk(LocalBackend.counterEquals(metrics.reporterSuccess, 1));
   });
@@ -96,7 +97,7 @@ describe('Composite and Remote Reporter should', () => {
     }).to.throw('RemoteReporter must be given a Sender.');
   });
 
-  it('failed to flush spans with reporter', () => {
+  it('failed to flush spans with reporter', done => {
     let mockSender = {
       flush: () => {
         return {
@@ -109,6 +110,7 @@ describe('Composite and Remote Reporter should', () => {
 
     reporter._sender = mockSender;
     reporter.flush();
+    done();
 
     assert.equal(logger._errorMsgs[0], 'Failed to flush spans in reporter.');
     assert.isOk(LocalBackend.counterEquals(metrics.reporterFailure, 1));

--- a/test/udp_sender.js
+++ b/test/udp_sender.js
@@ -189,7 +189,7 @@ describe('udp sender should', () => {
     });
   });
 
-  it('flush spans when capacity is reached', () => {
+  it('flush spans when capacity is reached', done => {
     let spanOne = tracer.startSpan('operation-one');
     spanOne.finish(); // finish to set span duration
     spanOne = ThriftUtils.spanToThrift(spanOne);
@@ -198,6 +198,7 @@ describe('udp sender should', () => {
 
     let responseOne = sender.append(spanOne);
     let responseTwo = sender.append(spanOne);
+    done();
 
     assert.equal(responseOne.err, false);
     assert.equal(responseOne.numSpans, 0);
@@ -208,7 +209,7 @@ describe('udp sender should', () => {
     assert.equal(sender._totalSpanBytes, 0);
   });
 
-  it('flush spans when just over capacity', () => {
+  it('flush spans when just over capacity', done => {
     let spanOne = tracer.startSpan('operation-one');
     spanOne.finish(); // finish to set span duration
     spanOne = ThriftUtils.spanToThrift(spanOne);
@@ -223,6 +224,7 @@ describe('udp sender should', () => {
     let responseOne = sender.append(spanOne);
     let responseTwo = sender.append(spanThatExceedsCapacity);
     let expectedBufferSize = sender._calcSpanSize(spanThatExceedsCapacity).length;
+    done();
 
     assert.equal(sender._batch.spans.length, 1);
     assert.equal(sender._totalSpanBytes, expectedBufferSize);
@@ -270,12 +272,13 @@ describe('udp sender should', () => {
     sender.close();
   });
 
-  it('return error response on span too large', () => {
+  it('return error response on span too large', done => {
     let span = tracer.startSpan('op-name');
     span.finish(); // otherwise duration will be undefined
 
     sender._maxSpanBytes = 1;
     let response = sender.append(ThriftUtils.spanToThrift(span));
+    done();
     assert.isOk(response.err);
     assert.equal(response.numSpans, 1);
     sender.flush();
@@ -284,8 +287,9 @@ describe('udp sender should', () => {
     sender.close();
   });
 
-  it('flush with no spans returns false for error, and 0', () => {
+  it('flush with no spans returns false for error, and 0', done => {
     let response = sender.flush();
+    done();
 
     assert.equal(response.err, false);
     assert.equal(response.numSpans, 0);


### PR DESCRIPTION
Flushes spans properly to backend
Signed-off-by: Kara de la Marck <karadelamarck@gmail.com>