### PR TITLE
Change UDPSender callbacks to (numSpans: number, err?: string) => void

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -12,3 +12,4 @@
 unsafe.enable_getters_and_setters=true
 suppress_comment= \\(.\\|\n\\)*\\$FlowIgnore
 esproposal.class_static_fields=enable
+esproposal.class_instance_fields=enable

--- a/src/_flow/reporter.js
+++ b/src/_flow/reporter.js
@@ -15,18 +15,15 @@ import Span from '../span.js';
 
 declare interface Reporter {
   report(span: Span): void;
-  close(callback: ?Function): void;
+  close(callback?: () => void): void;
   setProcess(serviceName: string, tags: Array<Tag>): void;
 }
 
 declare class Sender {
-  append(span: Span): SenderResponse;
-  flush(): SenderResponse;
+  append(span: Span, callback?: SenderCallback): void;
+  flush(callback?: SenderCallback): void;
   close(): void;
   setProcess(process: Process): void;
 }
 
-declare type SenderResponse = {
-  err: boolean,
-  numSpans: number,
-};
+declare type SenderCallback = (numSpans: number, err?: string) => void;

--- a/src/reporters/composite_reporter.js
+++ b/src/reporters/composite_reporter.js
@@ -30,18 +30,19 @@ export default class CompositeReporter {
     });
   }
 
-  compositeCallback(callback: ?Function): ?Function {
+  _compositeCallback(callback: () => void): () => void {
     let count = 0;
     return () => {
       count++;
       if (count >= this._reporters.length) {
-        if (callback) callback();
+        callback();
       }
     };
   }
 
-  close(callback: ?Function): void {
-    let modifiedCallback: ?Function = this.compositeCallback(callback);
+  close(callback?: () => void): void {
+    callback = callback || function() {};
+    let modifiedCallback = this._compositeCallback(callback);
     this._reporters.forEach(r => {
       r.close(modifiedCallback);
     });

--- a/src/reporters/composite_reporter.js
+++ b/src/reporters/composite_reporter.js
@@ -30,19 +30,20 @@ export default class CompositeReporter {
     });
   }
 
-  _compositeCallback(callback: () => void): () => void {
+  _compositeCallback(limit: number, callback: () => void): () => void {
     let count = 0;
     return () => {
       count++;
-      if (count >= this._reporters.length) {
+      if (count >= limit) {
         callback();
       }
     };
   }
 
   close(callback?: () => void): void {
-    callback = callback || function() {};
-    let modifiedCallback = this._compositeCallback(callback);
+    const modifiedCallback = callback
+      ? this._compositeCallback(this._reporters.length, callback)
+      : function() {};
     this._reporters.forEach(r => {
       r.close(modifiedCallback);
     });

--- a/src/reporters/in_memory_reporter.js
+++ b/src/reporters/in_memory_reporter.js
@@ -38,7 +38,7 @@ export default class InMemoryReporter {
     this._spans = [];
   }
 
-  close(callback: ?Function): void {
+  close(callback?: () => void): void {
     if (callback) {
       callback();
     }

--- a/src/reporters/logging_reporter.js
+++ b/src/reporters/logging_reporter.js
@@ -29,7 +29,7 @@ export default class LoggingReporter {
     return 'LoggingReporter';
   }
 
-  close(callback: ?Function): void {
+  close(callback?: () => void): void {
     if (callback) {
       callback();
     }

--- a/src/reporters/noop_reporter.js
+++ b/src/reporters/noop_reporter.js
@@ -20,7 +20,7 @@ export default class NoopReporter {
 
   report(span: Span): void {}
 
-  close(callback: ?Function): void {
+  close(callback?: () => void): void {
     if (callback) {
       callback();
     }

--- a/src/reporters/remote_reporter.js
+++ b/src/reporters/remote_reporter.js
@@ -45,35 +45,45 @@ export default class RemoteReporter {
   }
 
   report(span: Span): void {
-    this._sender.append(ThriftUtils.spanToThrift(span), (response: SenderResponse) => {
-      if (response.err) {
-        this._logger.error('Failed to append spans in reporter.');
-        this._metrics.reporterDropped.increment(response.numSpans);
+    let thriftSpan = ThriftUtils.spanToThrift(span);
+    this._sender.append(thriftSpan, (numSpans: number, err?: string) => {
+      if (err) {
+        this._logger.error(`Failed to append spans in reporter: ${err}`);
+        this._metrics.reporterDropped.increment(numSpans);
+      } else {
+        this._metrics.reporterSuccess.increment(numSpans);
       }
     });
   }
 
-  flush(callback: ?Function): void {
+  _invokeCallback(callback?: () => void): void {
+    if (callback) {
+      callback();
+    }
+  }
+
+  flush(callback?: () => void): void {
     if (this._process === undefined) {
-      this._logger.info('Failed to flush since process is not set.');
+      this._logger.error('Failed to flush since process is not set.');
+      this._invokeCallback(callback);
       return;
     }
-    this._sender.flush(response => {
-      if (response.err) {
-        this._logger.error('Failed to flush spans in reporter.');
-        this._metrics.reporterFailure.increment(response.numSpans);
+    this._sender.flush((numSpans: number, err?: string) => {
+      if (err) {
+        this._logger.error(`Failed to flush spans in reporter: ${err}`);
+        this._metrics.reporterFailure.increment(numSpans);
       } else {
-        this._metrics.reporterSuccess.increment(response.numSpans);
+        this._metrics.reporterSuccess.increment(numSpans);
       }
-      if (callback) callback();
+      this._invokeCallback(callback);
     });
   }
 
-  close(callback: ?Function): void {
+  close(callback?: () => void): void {
     clearInterval(this._intervalHandle);
     this.flush(() => {
       this._sender.close();
-      if (callback) callback();
+      this._invokeCallback(callback);
     });
   }
 

--- a/src/reporters/remote_reporter.js
+++ b/src/reporters/remote_reporter.js
@@ -45,16 +45,18 @@ export default class RemoteReporter {
   }
 
   report(span: Span): void {
-    let thriftSpan = ThriftUtils.spanToThrift(span);
-    this._sender.append(thriftSpan, (numSpans: number, err?: string) => {
-      if (err) {
-        this._logger.error(`Failed to append spans in reporter: ${err}`);
-        this._metrics.reporterDropped.increment(numSpans);
-      } else {
-        this._metrics.reporterSuccess.increment(numSpans);
-      }
-    });
+    const thriftSpan = ThriftUtils.spanToThrift(span);
+    this._sender.append(thriftSpan, this._appendCallback);
   }
+
+  _appendCallback = (numSpans: number, err?: string) => {
+    if (err) {
+      this._logger.error(`Failed to append spans in reporter: ${err}`);
+      this._metrics.reporterDropped.increment(numSpans);
+    } else {
+      this._metrics.reporterSuccess.increment(numSpans);
+    }
+  };
 
   _invokeCallback(callback?: () => void): void {
     if (callback) {

--- a/src/reporters/udp_sender.js
+++ b/src/reporters/udp_sender.js
@@ -91,7 +91,7 @@ export default class UDPSender {
     this._maxSpanBytes = this._maxPacketSize - this._emitSpanBatchOverhead;
   }
 
-  _invokeCallback(callback?: SenderCallback, numSpans, error) {
+  _invokeCallback(callback?: SenderCallback, numSpans: number, error?: string) {
     if (callback) {
       callback(numSpans, error);
     }
@@ -158,11 +158,12 @@ export default class UDPSender {
     // Having the error callback here does not prevent uncaught exception from being thrown,
     // that's why in the constructor we also add a general on('error') handler.
     this._client.send(thriftBuffer, 0, thriftBuffer.length, this._port, this._host, (err, sent) => {
-      this._invokeCallback(
-        callback,
-        numSpans,
-        err && `error sending spans over UDP: ${err}, packet size: ${writeResult.offset}, bytes sent: ${sent}`
-      );
+      if (err) {
+        let error: string = err && `error sending spans over UDP: ${err}, packet size: ${writeResult.offset}, bytes sent: ${sent}`;
+        this._invokeCallback(callback, numSpans, error);
+      } else {
+        this._invokeCallback(callback, numSpans);
+      }
     });
   }
 

--- a/src/reporters/udp_sender.js
+++ b/src/reporters/udp_sender.js
@@ -77,9 +77,9 @@ export default class UDPSender {
       spans: [],
     };
 
-    let tagMessages = [];
+    const tagMessages = [];
     for (let j = 0; j < this._batch.process.tags.length; j++) {
-      let tag = this._batch.process.tags[j];
+      const tag = this._batch.process.tags[j];
       tagMessages.push(new this._jaegerThrift.Tag(tag));
     }
 
@@ -98,12 +98,12 @@ export default class UDPSender {
   }
 
   append(span: any, callback?: SenderCallback): void {
-    let lengthResult: LengthResult = this._calcSpanSize(span);
-    if (lengthResult.err) {
-      this._invokeCallback(callback, 1, `error converting span to Thrift: ${lengthResult.err}`);
+    const { err, length } = this._calcSpanSize(span);
+    if (err) {
+      this._invokeCallback(callback, 1, `error converting span to Thrift: ${err}`);
       return;
     }
-    let spanSize: number = lengthResult.length;
+    const spanSize = length;
     if (spanSize > this._maxSpanBytes) {
       this._invokeCallback(
         callback,
@@ -135,15 +135,15 @@ export default class UDPSender {
   }
 
   flush(callback?: SenderCallback): void {
-    let numSpans: number = this._batch.spans.length;
-    if (numSpans == 0) {
+    const numSpans = this._batch.spans.length;
+    if (!numSpans) {
       this._invokeCallback(callback, 0);
       return;
     }
 
-    let bufferLen = this._totalSpanBytes + this._emitSpanBatchOverhead;
-    let thriftBuffer = new Buffer(bufferLen);
-    let writeResult = this._agentThrift.Agent.emitBatch.argumentsMessageRW.writeInto(
+    const bufferLen = this._totalSpanBytes + this._emitSpanBatchOverhead;
+    const thriftBuffer = new Buffer(bufferLen);
+    const writeResult = this._agentThrift.Agent.emitBatch.argumentsMessageRW.writeInto(
       this._convertBatchToThriftMessage(this._batch),
       thriftBuffer,
       0
@@ -159,7 +159,9 @@ export default class UDPSender {
     // that's why in the constructor we also add a general on('error') handler.
     this._client.send(thriftBuffer, 0, thriftBuffer.length, this._port, this._host, (err, sent) => {
       if (err) {
-        let error: string = err && `error sending spans over UDP: ${err}, packet size: ${writeResult.offset}, bytes sent: ${sent}`;
+        const error: string =
+          err &&
+          `error sending spans over UDP: ${err}, packet size: ${writeResult.offset}, bytes sent: ${sent}`;
         this._invokeCallback(callback, numSpans, error);
       } else {
         this._invokeCallback(callback, numSpans);
@@ -168,9 +170,9 @@ export default class UDPSender {
   }
 
   _convertBatchToThriftMessage() {
-    let spanMessages = [];
+    const spanMessages = [];
     for (let i = 0; i < this._batch.spans.length; i++) {
-      let span = this._batch.spans[i];
+      const span = this._batch.spans[i];
       spanMessages.push(new this._jaegerThrift.Span(span));
     }
 

--- a/src/reporters/udp_sender.js
+++ b/src/reporters/udp_sender.js
@@ -91,20 +91,25 @@ export default class UDPSender {
     this._maxSpanBytes = this._maxPacketSize - this._emitSpanBatchOverhead;
   }
 
-  append(span: any, callback: ?Function): void {
+  _invokeCallback(callback?: SenderCallback, numSpans, error) {
+    if (callback) {
+      callback(numSpans, error);
+    }
+  }
+
+  append(span: any, callback?: SenderCallback): void {
     let lengthResult: LengthResult = this._calcSpanSize(span);
     if (lengthResult.err) {
-      this._logger.error(`error converting span to Thrift: ${lengthResult.err}`);
-      if (callback) {
-        callback({ err: true, numSpans: 1 });
-      }
+      this._invokeCallback(callback, 1, `error converting span to Thrift: ${lengthResult.err}`);
       return;
     }
     let spanSize: number = lengthResult.length;
     if (spanSize > this._maxSpanBytes) {
-      if (callback) {
-        callback({ err: true, numSpans: 1 });
-      }
+      this._invokeCallback(
+        callback,
+        1,
+        `span size ${spanSize} is larger than maxSpanSize ${this._maxSpanBytes}`
+      );
       return;
     }
 
@@ -113,26 +118,26 @@ export default class UDPSender {
       this._totalSpanBytes += spanSize;
       if (this._totalSpanBytes < this._maxSpanBytes) {
         // still have space in the buffer, don't flush it yet
-        if (callback) {
-          callback({ err: false, numSpans: 0 });
-        }
+        this._invokeCallback(callback, 0);
         return;
       }
+      // buffer size === this._maxSpanBytes
       this.flush(callback);
       return;
     }
-    this.flush(result => {
+
+    this.flush((numSpans: number, err?: string) => {
+      // TODO theoretically we can have buffer overflow here too, if many spans were appended during flush()
       this._batch.spans.push(span);
       this._totalSpanBytes += spanSize;
+      this._invokeCallback(callback, numSpans, err);
     });
   }
 
-  flush(callback: ?Function): void {
+  flush(callback?: SenderCallback): void {
     let numSpans: number = this._batch.spans.length;
     if (numSpans == 0) {
-      if (callback) {
-        callback({ err: false, numSpans: 0 });
-      }
+      this._invokeCallback(callback, 0);
       return;
     }
 
@@ -146,24 +151,18 @@ export default class UDPSender {
     this._reset();
 
     if (writeResult.err) {
-      this._logger.error(`error writing Thrift object: ${writeResult.err}`);
-      if (callback) {
-        callback({ err: true, numSpans: numSpans });
-      }
+      this._invokeCallback(callback, numSpans, `error writing Thrift object: ${writeResult.err}`);
       return;
     }
 
     // Having the error callback here does not prevent uncaught exception from being thrown,
     // that's why in the constructor we also add a general on('error') handler.
     this._client.send(thriftBuffer, 0, thriftBuffer.length, this._port, this._host, (err, sent) => {
-      if (err) {
-        this._logger.error(
-          `error sending spans over UDP: ${err}, packet size: ${writeResult.offset}, bytes sent: ${sent}`
-        );
-      }
-      if (callback) {
-        callback({ err: err !== 0, numSpans: numSpans });
-      }
+      this._invokeCallback(
+        callback,
+        numSpans,
+        err && `error sending spans over UDP: ${err}, packet size: ${writeResult.offset}, bytes sent: ${sent}`
+      );
     });
   }
 

--- a/test/all_reporters.js
+++ b/test/all_reporters.js
@@ -65,11 +65,10 @@ describe('All Reporters should', () => {
   ];
 
   _.each(closeOptions, o => {
-    it('calls to close execute callback correctly', done => {
+    it('calls to close execute callback correctly', () => {
       let reporter = new CompositeReporter(reporters);
 
       reporter.close(o.callback);
-      done();
 
       assert.isOk(o.predicate(o.callback));
     });

--- a/test/all_reporters.js
+++ b/test/all_reporters.js
@@ -10,7 +10,6 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-import _ from 'lodash';
 import { assert } from 'chai';
 import CompositeReporter from '../src/reporters/composite_reporter';
 import InMemoryReporter from '../src/reporters/in_memory_reporter';
@@ -64,7 +63,7 @@ describe('All Reporters should', () => {
     },
   ];
 
-  _.each(closeOptions, o => {
+  closeOptions.forEach(o => {
     it('calls to close execute callback correctly', () => {
       let reporter = new CompositeReporter(reporters);
 

--- a/test/udp_sender.js
+++ b/test/udp_sender.js
@@ -28,7 +28,7 @@ import UDPSender from '../src/reporters/udp_sender.js';
 const PORT = 6832;
 const HOST = '127.0.0.1';
 
-describe('udp sender should', () => {
+describe('udp sender', () => {
   let server;
   let tracer;
   let thrift;
@@ -65,7 +65,14 @@ describe('udp sender should', () => {
     server.close();
   });
 
-  it('read and verify spans and process sent', done => {
+  function assertCallback(expectedNumSpans, expectedError): SenderCallback {
+    return (numSpans, error) => {
+      assert.equal(numSpans, expectedNumSpans);
+      assert.equal(error, expectedError);
+    };
+  }
+
+  it('should read and verify spans and process sent', done => {
     let spanOne = tracer.startSpan('operation-one');
     spanOne.finish(); // finish to set span duration
     spanOne = ThriftUtils.spanToThrift(spanOne);
@@ -99,9 +106,9 @@ describe('udp sender should', () => {
       done();
     });
 
-    sender.append(spanOne);
-    sender.append(spanTwo);
-    sender.flush();
+    sender.append(spanOne, assertCallback(0, undefined));
+    sender.append(spanTwo, assertCallback(0, undefined));
+    sender.flush(assertCallback(2, undefined));
   });
 
   describe('span reference tests', () => {
@@ -153,7 +160,7 @@ describe('udp sender should', () => {
     ];
 
     _.each(options, o => {
-      it('span references serialize', done => {
+      it('should serialize span references', done => {
         let span = tracer.startSpan('bender', {
           childOf: o.childOf,
           references: o.references,
@@ -189,27 +196,21 @@ describe('udp sender should', () => {
     });
   });
 
-  it('flush spans when capacity is reached', done => {
+  it('should flush spans when capacity is reached', () => {
     let spanOne = tracer.startSpan('operation-one');
     spanOne.finish(); // finish to set span duration
     spanOne = ThriftUtils.spanToThrift(spanOne);
     let spanSize = sender._calcSpanSize(spanOne).length;
     sender._maxSpanBytes = spanSize * 2;
 
-    let responseOne = sender.append(spanOne);
-    let responseTwo = sender.append(spanOne);
-    done();
-
-    assert.equal(responseOne.err, false);
-    assert.equal(responseOne.numSpans, 0);
-    assert.equal(responseTwo.err, false);
-    assert.equal(responseTwo.numSpans, 2);
+    sender.append(spanOne, assertCallback(0, undefined));
+    sender.append(spanOne, assertCallback(2, undefined));
 
     assert.equal(sender._batch.spans.length, 0);
     assert.equal(sender._totalSpanBytes, 0);
   });
 
-  it('flush spans when just over capacity', done => {
+  it('should flush spans when just over capacity', done => {
     let spanOne = tracer.startSpan('operation-one');
     spanOne.finish(); // finish to set span duration
     spanOne = ThriftUtils.spanToThrift(spanOne);
@@ -220,41 +221,33 @@ describe('udp sender should', () => {
     spanThatExceedsCapacity.setTag('some-key', 'some-value');
     spanThatExceedsCapacity.finish(); // finish to set span duration
     spanThatExceedsCapacity = ThriftUtils.spanToThrift(spanThatExceedsCapacity);
+    let largeSpanSize = sender._calcSpanSize(spanThatExceedsCapacity).length;
 
-    let responseOne = sender.append(spanOne);
-    let responseTwo = sender.append(spanThatExceedsCapacity);
-    let expectedBufferSize = sender._calcSpanSize(spanThatExceedsCapacity).length;
-    done();
+    sender.append(spanOne, assertCallback(0, undefined));
+    sender.append(spanThatExceedsCapacity, (numSpans, error) => {
+      assert.equal(numSpans, 1);
+      assert.equal(error, undefined);
 
-    assert.equal(sender._batch.spans.length, 1);
-    assert.equal(sender._totalSpanBytes, expectedBufferSize);
-    assert.equal(responseOne.err, false);
-    assert.equal(responseOne.numSpans, 0);
-    assert.equal(responseTwo.err, false);
-    assert.equal(responseTwo.numSpans, 1);
+      assert.equal(sender._batch.spans.length, 1);
+      assert.equal(sender._totalSpanBytes, largeSpanSize);
+      done();
+    });
   });
 
-  it('flush returns error, on failed buffer conversion', done => {
-    sender._logger = {
-      info: msg => {
-        console.log('sender info: ' + msg);
-      },
-      error: msg => {
-        expect(msg).to.have.string('error writing Thrift object:');
-        done();
-      },
-    };
+  it('should returns error from flush() on failed buffer conversion', done => {
     let span = tracer.startSpan('leela');
     span.finish(); // finish to set span duration
     span = ThriftUtils.spanToThrift(span);
     span.flags = 'string'; // malform the span to create a serialization error
     sender.append(span);
-    let response = sender.flush();
-    assert.isOk(response.err);
-    assert.equal(response.numSpans, 1);
+    sender.flush((numSpans, err) => {
+      assert.equal(numSpans, 1);
+      expect(err).to.have.string('error writing Thrift object:');
+      done();
+    });
   });
 
-  it('return error response upon thrift conversion failure', done => {
+  it('should return error upon thrift conversion failure', done => {
     sender._logger = {
       error: msg => {
         expect(msg).to.have.string('error converting span to Thrift:');
@@ -264,56 +257,51 @@ describe('udp sender should', () => {
     let span = tracer.startSpan(undefined);
     span.finish();
 
-    let response = sender.append(ThriftUtils.spanToThrift(span));
-    assert.isOk(response.err);
-    assert.equal(response.numSpans, 1);
-
-    // cleanup
-    sender.close();
+    sender.append(ThriftUtils.spanToThrift(span), (numSpans, err) => {
+      assert.equal(numSpans, 1);
+      expect(err).to.have.string('error converting span to Thrift:');
+      done();
+    });
   });
 
-  it('return error response on span too large', done => {
+  it('should return error on span too large', done => {
     let span = tracer.startSpan('op-name');
     span.finish(); // otherwise duration will be undefined
 
     sender._maxSpanBytes = 1;
-    let response = sender.append(ThriftUtils.spanToThrift(span));
-    done();
-    assert.isOk(response.err);
-    assert.equal(response.numSpans, 1);
-    sender.flush();
-
-    // cleanup
-    sender.close();
+    sender.append(ThriftUtils.spanToThrift(span), (numSpans, err) => {
+      assert.equal(numSpans, 1);
+      expect(err).to.have.string('is larger than maxSpanSize');
+      done();
+    });
   });
 
-  it('flush with no spans returns false for error, and 0', done => {
-    let response = sender.flush();
-    done();
-
-    assert.equal(response.err, false);
-    assert.equal(response.numSpans, 0);
+  it('should return 0,undefined on flush() with no spans', () => {
+    sender.flush(assertCallback(0, undefined));
   });
 
-  it('flush gracefully handles errors emitted by socket.send', done => {
+  it('should gracefully handle errors emitted by socket.send', done => {
     sender._host = 'foo.bar.xyz';
     // In Node 0.10 and 0.12 the error is logged twice: (1) from inline callback, (2) from on('error') handler.
-    let node0_10_12 = semver.satisfies(process.version, '0.10.x || 0.12.x');
-    let expectedLogs = node0_10_12 ? 2 : 1;
+    let expectLogs = semver.satisfies(process.version, '0.10.x || 0.12.x');
     sender._logger = {
       info: msg => {
         console.log('sender info: ' + msg);
       },
       error: msg => {
+        assert.isOk(expectLogs);
         expect(msg).to.have.string('error sending spans over UDP: Error: getaddrinfo ENOTFOUND');
-        expectedLogs--;
-        if (expectedLogs == 0) {
-          done();
-        }
+        done();
       },
     };
     let tracer = new Tracer('test-service-name', new RemoteReporter(sender), new ConstSampler(true));
     tracer.startSpan('testSpan').finish();
-    sender.flush();
+    sender.flush((numSpans, err) => {
+      assert.equal(numSpans, 1);
+      expect(err).to.have.string('error sending spans over UDP: Error: getaddrinfo ENOTFOUND');
+      if (!expectLogs) {
+        done();
+      }
+    });
   });
 });


### PR DESCRIPTION
* Add proper type signatures to UDPSender and Reporter callbacks (instead of `?Function`)
* Define sender callbacks as `(numSpans: number, err?: string) => void` instead of passing a `SenderResponse` object (avoids unnecessary memory allocation)
* Remove logging from UDPSender, instead return the error to the reporter that logs it
* Fix the tests (`done()` was called in the middle of some tests, aborting them prematurely)

Follow up to #224
Resolves #214 
Resolves #157 
Resolves #32 
Supersedes #166
