### PR TITLE
Pass logger/metrics option to remote sampler,reporter

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -53,7 +53,7 @@ let jaegerSchema = {
 };
 
 export default class Configuration {
-  static _getSampler(config) {
+  static _getSampler(config, options) {
     let type = config.sampler.type;
     let param = config.sampler.param;
     let host = config.sampler.host;
@@ -83,6 +83,8 @@ export default class Configuration {
         host: host,
         port: port,
         refreshInterval: refreshIntervalMs,
+        metrics: options.metrics,
+        logger: options.logger,
       });
     }
 
@@ -112,6 +114,8 @@ export default class Configuration {
         senderConfig['port'] = config.reporter.agentPort;
       }
     }
+    reporterConfig['metrics'] = options.metrics;
+    reporterConfig['logger'] = options.logger;
     let sender = new UDPSender(senderConfig);
     let remoteReporter = new RemoteReporter(sender, reporterConfig);
     if (reporters.length == 0) {
@@ -157,7 +161,7 @@ export default class Configuration {
       throw new Error(`config.serviceName must be provided`);
     }
     if (config.sampler) {
-      sampler = Configuration._getSampler(config);
+      sampler = Configuration._getSampler(config, options);
     } else {
       sampler = new RemoteSampler(config.serviceName, options);
     }

--- a/test/init_tracer.js
+++ b/test/init_tracer.js
@@ -167,4 +167,38 @@ describe('initTracer', () => {
     assert.equal(tracer._metrics._factory, metrics);
     assert.equal(tracer._tags['x'], 'y');
   });
+
+it('should pass options to remote sampler and reporter', () => {
+    let logger = {
+      info: function info(msg) {},
+    };
+    let metrics = {
+      createCounter: function createCounter() {
+        return {};
+      },
+      createGauge: function createGauge() {
+        return {};
+      },
+      createTimer: function createTimer() {
+        return {};
+      },
+    };
+    let tracer = initTracer(
+      {
+        serviceName: 'test-service',
+        sampler: {
+          type: 'remote',
+          param: 0,
+        }
+      },
+      {
+        logger: logger,
+        metrics: metrics,
+      }
+    );
+    assert.equal(tracer._reporter._metrics._factory, metrics);
+    assert.equal(tracer._reporter._logger, logger);
+    assert.equal(tracer._sampler._metrics._factory, metrics);
+    assert.equal(tracer._sampler._logger, logger);
+  });
 });


### PR DESCRIPTION
## Which problem is this PR solving?
When remote reporter and sampler are initialized via _getReporter and _getSampler, logger and metrics options are not passed into each constructor. 

Signed-off-by: eundoo-song <eundoo.song@samsung.com>