### PR TITLE
Update RateLimiter to scale credits on update

### DIFF
--- a/src/rate_limiter.js
+++ b/src/rate_limiter.js
@@ -30,9 +30,6 @@ export default class RateLimiter {
     // The new balance should be proportional to the old balance.
     this._balance = maxBalance * this._balance / this._maxBalance;
     this._maxBalance = maxBalance;
-    if (this._balance > maxBalance) {
-      this._balance = maxBalance;
-    }
   }
 
   checkCredit(itemCost: number): boolean {

--- a/src/rate_limiter.js
+++ b/src/rate_limiter.js
@@ -25,7 +25,10 @@ export default class RateLimiter {
   }
 
   update(creditsPerSecond: number, maxBalance: number) {
+    this._updateBalance();
     this._creditsPerSecond = creditsPerSecond;
+    // The new balance should be proportional to the old balance.
+    this._balance = maxBalance * this._balance / this._maxBalance;
     this._maxBalance = maxBalance;
     if (this._balance > maxBalance) {
       this._balance = maxBalance;
@@ -33,6 +36,15 @@ export default class RateLimiter {
   }
 
   checkCredit(itemCost: number): boolean {
+    this._updateBalance();
+    if (this._balance >= itemCost) {
+      this._balance -= itemCost;
+      return true;
+    }
+    return false;
+  }
+
+  _updateBalance() {
     let currentTime: number = new Date().getTime();
     let elapsedTime: number = (currentTime - this._lastTick) / 1000;
     this._lastTick = currentTime;
@@ -41,10 +53,5 @@ export default class RateLimiter {
     if (this._balance > this._maxBalance) {
       this._balance = this._maxBalance;
     }
-    if (this._balance >= itemCost) {
-      this._balance -= itemCost;
-      return true;
-    }
-    return false;
   }
 }

--- a/test/init_tracer.js
+++ b/test/init_tracer.js
@@ -168,7 +168,7 @@ describe('initTracer', () => {
     assert.equal(tracer._tags['x'], 'y');
   });
 
-it('should pass options to remote sampler and reporter', () => {
+  it('should pass options to remote sampler and reporter', () => {
     let logger = {
       info: function info(msg) {},
     };
@@ -189,7 +189,7 @@ it('should pass options to remote sampler and reporter', () => {
         sampler: {
           type: 'remote',
           param: 0,
-        }
+        },
       },
       {
         logger: logger,

--- a/test/throttler/remote_throttler.js
+++ b/test/throttler/remote_throttler.js
@@ -163,6 +163,7 @@ describe('RemoteThrottler should', () => {
     throttler.setProcess({ uuid: uuid });
     throttler._refreshCredits();
     sinon.assert.notCalled(throttler._fetchCredits);
+    throttler.close();
   });
 
   it('refresh credits after _afterInitialDelay is called', done => {

--- a/test/udp_sender.js
+++ b/test/udp_sender.js
@@ -294,7 +294,7 @@ describe('udp sender', () => {
         done();
       },
     };
-    let tracer = new Tracer('test-service-name', new RemoteReporter(sender), new ConstSampler(true));
+    tracer = new Tracer('test-service-name', new RemoteReporter(sender), new ConstSampler(true));
     tracer.startSpan('testSpan').finish();
     sender.flush((numSpans, err) => {
       assert.equal(numSpans, 1);

--- a/test/udp_sender.js
+++ b/test/udp_sender.js
@@ -281,11 +281,7 @@ describe('udp sender', () => {
   });
 
   it('should gracefully handle errors emitted by socket.send', done => {
-    const tracer = new Tracer('test-service-name', new RemoteReporter(sender), new ConstSampler(true));
-    const doneWrapper = function() {
-      tracer.close();
-      done();
-    };
+    let tracer = new Tracer('test-service-name', new RemoteReporter(sender), new ConstSampler(true));
     sender._host = 'foo.bar.xyz';
     // In Node 0.10 and 0.12 the error is logged twice: (1) from inline callback, (2) from on('error') handler.
     let expectLogs = semver.satisfies(process.version, '0.10.x || 0.12.x');
@@ -296,7 +292,8 @@ describe('udp sender', () => {
       error: msg => {
         assert.isOk(expectLogs);
         expect(msg).to.have.string('error sending spans over UDP: Error: getaddrinfo ENOTFOUND');
-        doneWrapper();
+        tracer.close();
+        done();
       },
     };
     tracer.startSpan('testSpan').finish();
@@ -305,7 +302,7 @@ describe('udp sender', () => {
       expect(err).to.have.string('error sending spans over UDP: Error: getaddrinfo ENOTFOUND');
       if (!expectLogs) {
         tracer.close();
-        doneWrapper();
+        done();
       }
     });
   });


### PR DESCRIPTION
The current update function truncates the balance on update instead of scaling it proportionally with respect to the old range and the new range. By scaling, we maintain the randomness in the balances across clients.

Signed-off-by: Won Jun Jang <wjang@uber.com>