### PR TITLE
Rename TRACER_HOSTNAME_TAG_KEY #250  - change constant

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -20,7 +20,7 @@ export const DEBUG_MASK = 0x2;
 export const JAEGER_CLIENT_VERSION_TAG_KEY = 'jaeger.version';
 
 // TRACER_HOSTNAME_TAG_KEY used to report host name of the process.
-export const TRACER_HOSTNAME_TAG_KEY = 'jaeger.hostname';
+export const TRACER_HOSTNAME_TAG_KEY = 'hostname';
 
 // PROCESS_IP used to report ip of the process.
 export const PROCESS_IP = 'ip';


### PR DESCRIPTION

## Which problem is this PR solving?
- This is a fix for Rename TRACER_HOSTNAME_TAG_KEY #250 which is a good first issue.

## Short description of the changes
- Had changed the constant TRACER_HOSTNAME_TAG_KEY from 'jaeger.hostname' to 'hostname'.
