### PR TITLE
Pass object to prom-client metric to fix warning

### DIFF
--- a/src/metrics/prometheus.js
+++ b/src/metrics/prometheus.js
@@ -75,7 +75,7 @@ export default class PrometheusMetricsFactory {
       name = this._namespace + '_' + name;
     }
     if (!(key in this._cache)) {
-      this._cache[key] = new metric(name, help, labelNames);
+      this._cache[key] = new metric({ name, help, labelNames });
     }
     return labelValues.length > 0 ? this._cache[key].labels(...labelValues) : this._cache[key];
   }


### PR DESCRIPTION
Signed-off-by: Eundoo Song <eundoo.song@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

- This removes prom-client warning called when a metric is constructed.

## Short description of the changes

- Passing a non-object to metrics constructor is deprecated. So it shows below warning when a metric is constructed.
```
(node:49239) DeprecationWarning: prom-client - Passing a non-object to metrics constructor is deprecated
```
prom-client code : https://github.com/siimon/prom-client/blob/v11.0.0/lib/counter.js#L30,L42
