### PR TITLE
Fix Invalid metric name: Rename throttler-update to throttler_update

### DIFF
--- a/src/metrics/metrics.js
+++ b/src/metrics/metrics.js
@@ -113,7 +113,7 @@ export default class Metrics {
 
     this.throttledDebugSpans = this._factory.createCounter('jaeger:throttled_debug_spans');
 
-    this.throttlerUpdateSuccess = this._factory.createCounter('jaeger:throttler-update', {
+    this.throttlerUpdateSuccess = this._factory.createCounter('jaeger:throttler_update', {
       result: 'ok',
     });
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- When using `prom-client` as in the example
```
/Users/yknx4/Projects/price-tracker/node_modules/prom-client/lib/counter.js:60
                        throw new Error('Invalid metric name');
                        ^

Error: Invalid metric name
    at new Counter (/Users/yknx4/Projects/price-tracker/node_modules/prom-client/lib/counter.js:60:10)
    at PrometheusMetricsFactory._createMetric (/Users/yknx4/Projects/price-tracker/node_modules/jaeger-client/dist/src/metrics/prometheus.js:102:28)
    at PrometheusMetricsFactory.createCounter (/Users/yknx4/Projects/price-tracker/node_modules/jaeger-client/dist/src/metrics/prometheus.js:117:42)
    at new Metrics (/Users/yknx4/Projects/price-tracker/node_modules/jaeger-client/dist/src/metrics/metrics.js:100:47)
    at Object.initTracer (/Users/yknx4/Projects/price-tracker/node_modules/jaeger-client/dist/src/configuration.js:246:27)
    at Object.<anonymous> (/Users/yknx4/Projects/price-tracker/lib/services/apm.js:17:34)
    at Module._compile (internal/modules/cjs/loader.js:702:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:713:10)
    at Module.load (internal/modules/cjs/loader.js:612:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:551:12)
    at Function.Module._load (internal/modules/cjs/loader.js:543:3)
    at Module.require (internal/modules/cjs/loader.js:650:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (/Users/yknx4/Projects/price-tracker/lib/routes.js:8:1)
    at Module._compile (internal/modules/cjs/loader.js:702:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:713:10)
```

## Short description of the changes

- rename `jager:throttler-update` to `jagger:throttler_update` in `metrics/metrics.js:116` because `-` is a non valid character for metric names.
