### PR TITLE
Add HTTP Sender

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -46,10 +46,9 @@ let jaegerSchema = {
     reporter: {
       properties: {
         logSpans: { type: 'boolean' },
-        agentProtocol: { type: 'string' },
         agentHost: { type: 'string' },
         agentPort: { type: 'number' },
-        agentPath: { type: 'string' },
+        collectorEndpoint: { type: 'string' },
         username: { type: 'string' },
         password: { type: 'string' },
         flushIntervalMs: { type: 'number' },
@@ -122,13 +121,11 @@ export default class Configuration {
         reporterConfig['bufferFlushInterval'] = config.reporter.flushIntervalMs;
       }
 
-      if (config.reporter.agentProtocol === 'http' || config.reporter.agentProtocol === 'https') {
+      if (config.reporter.collectorEndpoint) {
         isHTTPSender = true;
-        senderConfig['useHTTPS'] = config.reporter.agentProtocol === 'https';
 
-        if (config.reporter.agentPath) {
-          senderConfig['path'] = config.reporter.agentPath;
-        }
+        senderConfig['endpoint'] = config.reporter.collectorEndpoint;
+
         if (config.reporter.username) {
           senderConfig['username'] = config.reporter.username;
         }

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -109,7 +109,7 @@ export default class Configuration {
   static _getReporter(config, options) {
     let reporterConfig = {};
     let reporters = [];
-    let senderCls = UDPSender;
+    let isHTTPSender = false;
     let senderConfig = {
       logger: options.logger,
     };
@@ -123,7 +123,7 @@ export default class Configuration {
       }
 
       if (config.reporter.agentProtocol === 'http' || config.reporter.agentProtocol === 'https') {
-        senderCls = HTTPSender;
+        isHTTPSender = true;
         senderConfig['useHTTPS'] = config.reporter.agentProtocol === 'https';
 
         if (config.reporter.agentPath) {
@@ -146,7 +146,7 @@ export default class Configuration {
     }
     reporterConfig['metrics'] = options.metrics;
     reporterConfig['logger'] = options.logger;
-    let sender = new senderCls(senderConfig);
+    let sender = isHTTPSender ? new HTTPSender(senderConfig) : new UDPSender(senderConfig);
     let remoteReporter = new RemoteReporter(sender, reporterConfig);
     if (reporters.length == 0) {
       return remoteReporter;

--- a/src/reporters/http_sender.js
+++ b/src/reporters/http_sender.js
@@ -1,0 +1,140 @@
+// @flow
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+import fs from 'fs';
+import http from 'http';
+import path from 'path';
+import * as url from 'url';
+import { Thrift } from 'thriftrw';
+import NullLogger from '../logger.js';
+import SenderUtils from './sender_utils.js';
+
+const DEFAULT_PATH = '/api/traces';
+const DEFAULT_PORT = 14268;
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_MAX_SPAN_BATCH_SIZE = 100;
+
+export default class HTTPSender {
+  _url: Object;
+  _username: string;
+  _password: string;
+  _emitSpanBatchOverhead: number;
+  _timeoutMS: number;
+  _httpAgent: http$Agent;
+  _logger: Logger;
+  _jaegerThrift: Thrift;
+  _process: Process;
+  _batch: Batch;
+  _thriftProcessMessage: any;
+  _maxSpanBatchSize: number;
+
+  constructor(options: any = {}) {
+    this._url = url.parse(
+      `${options.useHTTPS ? 'https' : 'http'}://${options.host || 'localhost'}:${options.port ||
+        DEFAULT_PORT}${options.path || DEFAULT_PATH}`
+    );
+    this._username = options.username;
+    this._password = options.password;
+    this._timeoutMS = options.timeoutMS || DEFAULT_TIMEOUT_MS;
+    this._httpAgent = new http.Agent({ keepAlive: true });
+
+    this._maxSpanBatchSize = options.maxSpanBatchSize || DEFAULT_MAX_SPAN_BATCH_SIZE;
+
+    this._logger = options.logger || new NullLogger();
+    this._jaegerThrift = new Thrift({
+      source: fs.readFileSync(path.join(__dirname, '../jaeger-idl/thrift/jaeger.thrift'), 'ascii'),
+      allowOptionalArguments: true,
+    });
+  }
+
+  setProcess(process: Process): void {
+    const tagMessages = [];
+    for (let j = 0; j < process.tags.length; j++) {
+      const tag = process.tags[j];
+      tagMessages.push(new this._jaegerThrift.Tag(tag));
+    }
+
+    // Go ahead and initialize the Thrift batch that we will reuse for each
+    // flush.
+    this._batch = new this._jaegerThrift.Batch({
+      process: new this._jaegerThrift.Process({
+        serviceName: process.serviceName,
+        tags: tagMessages,
+      }),
+      spans: [],
+    });
+  }
+
+  append(span: any, callback?: SenderCallback): void {
+    this._batch.spans.push(new this._jaegerThrift.Span(span));
+
+    if (this._batch.spans.length >= this._maxSpanBatchSize) {
+      this.flush(callback);
+      return;
+    }
+    SenderUtils.invokeCallback(callback, 0);
+  }
+
+  flush(callback?: SenderCallback): void {
+    const numSpans = this._batch.spans.length;
+    if (!numSpans) {
+      SenderUtils.invokeCallback(callback, 0);
+      return;
+    }
+
+    const result = this._jaegerThrift.Batch.rw.toBuffer(this._batch);
+    if (result.err) {
+      SenderUtils.invokeCallback(callback, numSpans, `Error encoding Thrift batch: ${result.err}`);
+      return;
+    }
+
+    this._reset();
+
+    const options = {
+      protocol: this._url.protocol,
+      hostname: this._url.hostname,
+      port: this._url.port,
+      path: this._url.pathname,
+      method: 'POST',
+      auth: this._username && this._password ? `${this._username}:${this._password}` : undefined,
+      headers: {
+        'Content-Type': 'application/x-thrift',
+        Connection: 'keep-alive',
+      },
+      agent: this._httpAgent,
+      timeout: this._timeoutMS,
+    };
+    const req = http.request(options, resp => {
+      SenderUtils.invokeCallback(callback, numSpans);
+    });
+
+    req.on('error', err => {
+      const error: string = `error sending spans over HTTP: ${err}`;
+      this._logger.error(error);
+      SenderUtils.invokeCallback(callback, numSpans, error);
+    });
+    req.write(result.value);
+    req.end();
+  }
+
+  _reset() {
+    this._batch.spans = [];
+  }
+
+  close(): void {
+    // Older node versions don't have this.
+    if (this._httpAgent.destroy) {
+      this._httpAgent.destroy();
+    }
+  }
+}

--- a/src/reporters/sender_utils.js
+++ b/src/reporters/sender_utils.js
@@ -1,0 +1,20 @@
+// @flow
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+export default class SenderUtils {
+  static invokeCallback(callback?: SenderCallback, numSpans: number, error?: string) {
+    if (callback) {
+      callback(numSpans, error);
+    }
+  }
+}

--- a/src/reporters/sender_utils.js
+++ b/src/reporters/sender_utils.js
@@ -11,10 +11,25 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
+import { Thrift } from 'thriftrw';
+
 export default class SenderUtils {
   static invokeCallback(callback?: SenderCallback, numSpans: number, error?: string) {
     if (callback) {
       callback(numSpans, error);
     }
+  }
+
+  static convertProcessToThrift(t: Thrift, process: Process) {
+    const tagMessages = [];
+    for (let j = 0; j < process.tags.length; j++) {
+      const tag = process.tags[j];
+      tagMessages.push(new t.Tag(tag));
+    }
+
+    return new t.Process({
+      serviceName: process.serviceName,
+      tags: tagMessages,
+    });
   }
 }

--- a/src/reporters/udp_sender.js
+++ b/src/reporters/udp_sender.js
@@ -16,6 +16,7 @@ import fs from 'fs';
 import path from 'path';
 import { Thrift } from 'thriftrw';
 import NullLogger from '../logger.js';
+import SenderUtils from './sender_utils.js';
 
 const HOST = 'localhost';
 const PORT = 6832;
@@ -91,21 +92,15 @@ export default class UDPSender {
     this._maxSpanBytes = this._maxPacketSize - this._emitSpanBatchOverhead;
   }
 
-  _invokeCallback(callback?: SenderCallback, numSpans: number, error?: string) {
-    if (callback) {
-      callback(numSpans, error);
-    }
-  }
-
   append(span: any, callback?: SenderCallback): void {
     const { err, length } = this._calcSpanSize(span);
     if (err) {
-      this._invokeCallback(callback, 1, `error converting span to Thrift: ${err}`);
+      SenderUtils.invokeCallback(callback, 1, `error converting span to Thrift: ${err}`);
       return;
     }
     const spanSize = length;
     if (spanSize > this._maxSpanBytes) {
-      this._invokeCallback(
+      SenderUtils.invokeCallback(
         callback,
         1,
         `span size ${spanSize} is larger than maxSpanSize ${this._maxSpanBytes}`
@@ -118,7 +113,7 @@ export default class UDPSender {
       this._totalSpanBytes += spanSize;
       if (this._totalSpanBytes < this._maxSpanBytes) {
         // still have space in the buffer, don't flush it yet
-        this._invokeCallback(callback, 0);
+        SenderUtils.invokeCallback(callback, 0);
         return;
       }
       // buffer size === this._maxSpanBytes
@@ -130,14 +125,14 @@ export default class UDPSender {
       // TODO theoretically we can have buffer overflow here too, if many spans were appended during flush()
       this._batch.spans.push(span);
       this._totalSpanBytes += spanSize;
-      this._invokeCallback(callback, numSpans, err);
+      SenderUtils.invokeCallback(callback, numSpans, err);
     });
   }
 
   flush(callback?: SenderCallback): void {
     const numSpans = this._batch.spans.length;
     if (!numSpans) {
-      this._invokeCallback(callback, 0);
+      SenderUtils.invokeCallback(callback, 0);
       return;
     }
 
@@ -151,7 +146,7 @@ export default class UDPSender {
     this._reset();
 
     if (writeResult.err) {
-      this._invokeCallback(callback, numSpans, `error writing Thrift object: ${writeResult.err}`);
+      SenderUtils.invokeCallback(callback, numSpans, `error writing Thrift object: ${writeResult.err}`);
       return;
     }
 
@@ -162,9 +157,9 @@ export default class UDPSender {
         const error: string =
           err &&
           `error sending spans over UDP: ${err}, packet size: ${writeResult.offset}, bytes sent: ${sent}`;
-        this._invokeCallback(callback, numSpans, error);
+        SenderUtils.invokeCallback(callback, numSpans, error);
       } else {
-        this._invokeCallback(callback, numSpans);
+        SenderUtils.invokeCallback(callback, numSpans);
       }
     });
   }

--- a/src/reporters/udp_sender.js
+++ b/src/reporters/udp_sender.js
@@ -78,16 +78,7 @@ export default class UDPSender {
       spans: [],
     };
 
-    const tagMessages = [];
-    for (let j = 0; j < this._batch.process.tags.length; j++) {
-      const tag = this._batch.process.tags[j];
-      tagMessages.push(new this._jaegerThrift.Tag(tag));
-    }
-
-    this._thriftProcessMessage = new this._jaegerThrift.Process({
-      serviceName: this._batch.process.serviceName,
-      tags: tagMessages,
-    });
+    this._thriftProcessMessage = SenderUtils.convertProcessToThrift(this._jaegerThrift, process);
     this._emitSpanBatchOverhead = this._calcBatchSize(this._batch);
     this._maxSpanBytes = this._maxPacketSize - this._emitSpanBatchOverhead;
   }

--- a/test/http_sender.js
+++ b/test/http_sender.js
@@ -138,71 +138,39 @@ describe('http sender', () => {
       { childOf: null, references: [], expectedTraceId: null, expectedParentId: null },
       {
         childOf: parentContext,
-        references: [],
-        expectedTraceId: parentContext.traceId,
-        expectedParentId: parentContext.parentId,
-      },
-      {
-        childOf: parentContext,
-        references: [followsFromRef],
-        expectedTraceId: parentContext.traceId,
-        expectedParentId: parentContext.parentId,
-      },
-      {
-        childOf: parentContext,
         references: [childOfRef, followsFromRef],
         expectedTraceId: parentContext.traceId,
         expectedParentId: parentContext.parentId,
-      },
-      {
-        childOf: null,
-        references: [childOfRef],
-        expectedTraceId: childOfContext.traceId,
-        expectedParentId: childOfContext.parentId,
-      },
-      {
-        childOf: null,
-        references: [followsFromRef],
-        expectedTraceId: followsFromContext.traceId,
-        expectedParentId: followsFromContext.parentId,
-      },
-      {
-        childOf: null,
-        references: [childOfRef, followsFromRef],
-        expectedTraceId: childOfContext.traceId,
-        expectedParentId: childOfContext.parentId,
       },
     ];
 
     _.each(options, o => {
       it('should serialize span references', done => {
-        let span = tracer.startSpan('bender', {
+        const span = tracer.startSpan('bender', {
           childOf: o.childOf,
           references: o.references,
         });
         span.finish();
-        span = ThriftUtils.spanToThrift(span);
+        const tSpan = ThriftUtils.spanToThrift(span);
 
         server.on('batchReceived', function(batch) {
-          let span = batch.spans[0];
-          let ref = span.references[0];
-
           assert.isOk(batch);
-          assertThriftSpanEqual(assert, span, batch.spans[0]);
+          assertThriftSpanEqual(assert, tSpan, batch.spans[0]);
+
           if (o.expectedTraceId) {
-            assert.deepEqual(span.traceIdLow, o.expectedTraceId);
+            assert.deepEqual(batch.spans[0].traceIdLow, o.expectedTraceId);
           }
 
           if (o.expectedParentId) {
-            assert.deepEqual(span.parentId, o.expectedParentId);
+            assert.deepEqual(batch.spans[0].parentId, o.expectedParentId);
           } else {
-            assert.isNotOk(span.parentId);
+            assert.isNotOk(batch.spans[0].parentId);
           }
 
           done();
         });
 
-        sender.append(span);
+        sender.append(tSpan);
         sender.flush();
       });
     });

--- a/test/http_sender.js
+++ b/test/http_sender.js
@@ -1,0 +1,275 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+import _ from 'lodash';
+import express from 'express';
+import * as url from 'url';
+import { raw } from 'body-parser';
+import { assert, expect } from 'chai';
+import ConstSampler from '../src/samplers/const_sampler.js';
+import fs from 'fs';
+import path from 'path';
+import semver from 'semver';
+import InMemoryReporter from '../src/reporters/in_memory_reporter.js';
+import RemoteReporter from '../src/reporters/remote_reporter.js';
+import opentracing from 'opentracing';
+import Tracer from '../src/tracer.js';
+import { Thrift } from 'thriftrw';
+import ThriftUtils from '../src/thrift.js';
+import HTTPSender from '../src/reporters/http_sender.js';
+
+const batchSize = 100;
+
+describe('http sender', () => {
+  let app;
+  let server;
+  let tracer;
+  let thrift;
+  let sender;
+
+  function assertThriftSpanEqual(assert, spanOne, spanTwo) {
+    assert.deepEqual(spanOne.traceIdLow, spanTwo.traceIdLow);
+    assert.deepEqual(spanOne.traceIdHigh, spanTwo.traceIdHigh);
+    assert.deepEqual(spanOne.spanId, spanTwo.spanId);
+    assert.deepEqual(spanOne.parentSpanId, spanTwo.parentSpanId);
+    assert.equal(spanOne.operationName, spanTwo.operationName);
+    assert.deepEqual(spanOne.references, spanTwo.references);
+    assert.equal(spanOne.flags, spanTwo.flags);
+    assert.deepEqual(spanOne.startTime, spanTwo.startTime);
+    assert.deepEqual(spanOne.duration, spanTwo.duration);
+  }
+
+  beforeEach(() => {
+    thrift = new Thrift({
+      source: fs.readFileSync(path.join(__dirname, '../src/jaeger-idl/thrift/jaeger.thrift'), 'ascii'),
+      allowOptionalArguments: true,
+    });
+
+    app = express();
+    app.use(raw({ type: 'application/x-thrift' }));
+    app.post('/api/traces', (req, res) => {
+      if (req.headers.authorization) {
+        const b64auth = (req.headers.authorization || '').split(' ')[1] || '';
+        const [username, password] = new Buffer(b64auth, 'base64').toString().split(':');
+        server.emit('authReceived', [username, password]);
+      }
+      let thriftObj = thrift.Batch.rw.readFrom(req.body, 0);
+      let batch = thriftObj.value;
+      if (batch) {
+        server.emit('batchReceived', batch);
+      }
+      res.status(202).send('');
+    });
+    server = app.listen(0);
+
+    let reporter = new InMemoryReporter();
+    tracer = new Tracer('test-service-name', reporter, new ConstSampler(true));
+    sender = new HTTPSender({
+      port: server.address().port,
+      maxSpanBatchSize: batchSize,
+    });
+    sender.setProcess(reporter._process);
+  });
+
+  afterEach(() => {
+    tracer.close();
+    server.close();
+  });
+
+  function assertCallback(expectedNumSpans, expectedError): SenderCallback {
+    return (numSpans, error) => {
+      assert.equal(numSpans, expectedNumSpans);
+      assert.equal(error, expectedError);
+    };
+  }
+
+  it('should read and verify spans and process sent', done => {
+    let spanOne = tracer.startSpan('operation-one');
+    spanOne.finish(); // finish to set span duration
+    spanOne = ThriftUtils.spanToThrift(spanOne);
+    let spanTwo = tracer.startSpan('operation-two');
+    spanTwo.finish(); // finish to set span duration
+    spanTwo = ThriftUtils.spanToThrift(spanTwo);
+
+    server.on('batchReceived', batch => {
+      assert.isOk(batch);
+      assert.equal(batch.spans.length, 2);
+
+      assertThriftSpanEqual(assert, spanOne, batch.spans[0]);
+      assertThriftSpanEqual(assert, spanTwo, batch.spans[1]);
+
+      assert.equal(batch.process.serviceName, 'test-service-name');
+      let actualTags = _.sortBy(batch.process.tags, o => {
+        return o.key;
+      });
+      assert.equal(actualTags.length, 4);
+      assert.equal(actualTags[0].key, 'client-uuid');
+      assert.equal(actualTags[1].key, 'ip');
+      assert.equal(actualTags[2].key, 'jaeger.hostname');
+      assert.equal(actualTags[3].key, 'jaeger.version');
+    });
+
+    sender.append(spanOne, assertCallback(0, undefined));
+    sender.append(spanTwo, assertCallback(0, undefined));
+    sender.flush((numSpans, error) => {
+      assertCallback(2, undefined)(numSpans, error);
+      done();
+    });
+  });
+
+  describe('span reference tests', () => {
+    let tracer = new Tracer('test-service-name', new InMemoryReporter(), new ConstSampler(true));
+    let parentContext = tracer.startSpan('just-used-for-context').context();
+    let childOfContext = tracer.startSpan('just-used-for-context').context();
+    let childOfRef = new opentracing.Reference(opentracing.REFERENCE_CHILD_OF, childOfContext);
+    let followsFromContext = tracer.startSpan('just-used-for-context').context();
+    let followsFromRef = new opentracing.Reference(opentracing.REFERENCE_FOLLOWS_FROM, followsFromContext);
+
+    let options = [
+      { childOf: null, references: [], expectedTraceId: null, expectedParentId: null },
+      {
+        childOf: parentContext,
+        references: [],
+        expectedTraceId: parentContext.traceId,
+        expectedParentId: parentContext.parentId,
+      },
+      {
+        childOf: parentContext,
+        references: [followsFromRef],
+        expectedTraceId: parentContext.traceId,
+        expectedParentId: parentContext.parentId,
+      },
+      {
+        childOf: parentContext,
+        references: [childOfRef, followsFromRef],
+        expectedTraceId: parentContext.traceId,
+        expectedParentId: parentContext.parentId,
+      },
+      {
+        childOf: null,
+        references: [childOfRef],
+        expectedTraceId: childOfContext.traceId,
+        expectedParentId: childOfContext.parentId,
+      },
+      {
+        childOf: null,
+        references: [followsFromRef],
+        expectedTraceId: followsFromContext.traceId,
+        expectedParentId: followsFromContext.parentId,
+      },
+      {
+        childOf: null,
+        references: [childOfRef, followsFromRef],
+        expectedTraceId: childOfContext.traceId,
+        expectedParentId: childOfContext.parentId,
+      },
+    ];
+
+    _.each(options, o => {
+      it('should serialize span references', done => {
+        let span = tracer.startSpan('bender', {
+          childOf: o.childOf,
+          references: o.references,
+        });
+        span.finish();
+        span = ThriftUtils.spanToThrift(span);
+
+        server.on('batchReceived', function(batch) {
+          let span = batch.spans[0];
+          let ref = span.references[0];
+
+          assert.isOk(batch);
+          assertThriftSpanEqual(assert, span, batch.spans[0]);
+          if (o.expectedTraceId) {
+            assert.deepEqual(span.traceIdLow, o.expectedTraceId);
+          }
+
+          if (o.expectedParentId) {
+            assert.deepEqual(span.parentId, o.expectedParentId);
+          } else {
+            assert.isNotOk(span.parentId);
+          }
+
+          done();
+        });
+
+        sender.append(span);
+        sender.flush();
+      });
+    });
+  });
+
+  it('should flush spans when capacity is reached', done => {
+    const spans = [];
+    for (let i = 0; i < batchSize; i++) {
+      let s = tracer.startSpan(`operation-${i}`);
+      s.finish();
+      spans.push(ThriftUtils.spanToThrift(s));
+    }
+
+    for (let i = 0; i < batchSize - 1; i++) {
+      sender.append(spans[i], assertCallback(0, undefined));
+    }
+
+    sender.append(spans[batchSize - 1], assertCallback(batchSize, undefined));
+
+    server.on('batchReceived', batch => {
+      done();
+    });
+  });
+
+  it('should use basic auth if username/password provided', done => {
+    sender._username = 'me';
+    sender._password = 's3cr3t';
+
+    const s = tracer.startSpan('operation-one');
+    s.finish();
+    sender.append(ThriftUtils.spanToThrift(s), assertCallback(0, undefined));
+    sender.flush();
+
+    server.on('authReceived', creds => {
+      expect(creds[0]).to.equal('me');
+      expect(creds[1]).to.equal('s3cr3t');
+      done();
+    });
+  });
+
+  it('should returns error from flush() on failed buffer conversion', done => {
+    let span = tracer.startSpan('leela');
+    span.finish(); // finish to set span duration
+    span = ThriftUtils.spanToThrift(span);
+    span.flags = 'string'; // malform the span to create a serialization error
+
+    sender.append(span);
+    sender.flush((numSpans, err) => {
+      assert.equal(numSpans, 1);
+      expect(err).to.have.string('Error encoding Thrift batch:');
+      done();
+    });
+  });
+
+  it('should return 0,undefined on flush() with no spans', () => {
+    sender.flush(assertCallback(0, undefined));
+  });
+
+  it('should gracefully handle errors emitted by socket.send', done => {
+    sender._url = url.parse('http://foo.bar.xyz');
+    let tracer = new Tracer('test-service-name', new RemoteReporter(sender), new ConstSampler(true));
+
+    tracer.startSpan('testSpan').finish();
+    sender.flush((numSpans, err) => {
+      assert.equal(numSpans, 1);
+      expect(err).to.have.string('error sending spans over HTTP: Error: getaddrinfo ENOTFOUND');
+      tracer.close(done);
+    });
+  });
+});

--- a/test/init_tracer.js
+++ b/test/init_tracer.js
@@ -173,10 +173,7 @@ describe('initTracer', () => {
           },
           reporter: {
             logSpans: true,
-            agentProtocol: protocol,
-            agentHost: '127.0.0.1',
-            agentPort: 4939,
-            agentPath: '/my/path',
+            collectorEndpoint: `${protocol}://127.0.0.1:4939/my/path`,
             username: protocol === 'https' ? 'test' : undefined,
             password: protocol === 'https' ? 'mypass' : undefined,
             flushIntervalMs: 2000,

--- a/test/init_tracer.js
+++ b/test/init_tracer.js
@@ -11,6 +11,7 @@
 // the License.
 
 import _ from 'lodash';
+import * as url from 'url';
 import { assert, expect } from 'chai';
 import CompositeReporter from '../src/reporters/composite_reporter';
 import RemoteReporter from '../src/reporters/remote_reporter';
@@ -22,6 +23,8 @@ import { initTracer } from '../src/index.js';
 import opentracing from 'opentracing';
 import RemoteThrottler from '../src/throttler/remote_throttler';
 import DefaultThrottler from '../src/throttler/default_throttler';
+import HTTPSender from '../src/reporters/http_sender.js';
+import UDPSender from '../src/reporters/udp_sender.js';
 
 const logger = {
   info: function info(msg) {},
@@ -126,36 +129,76 @@ describe('initTracer', () => {
     assert.equal(count, 4);
   });
 
-  it('should respect reporter options', done => {
-    let config = {
-      serviceName: 'test-service',
-      sampler: {
-        type: 'const',
-        param: 0,
-      },
-      reporter: {
-        logSpans: true,
-        agentHost: '127.0.0.1',
-        agentPort: 4939,
-        flushIntervalMs: 2000,
-      },
-    };
-    let tracer = initTracer(config);
+  describe('reporter options', () => {
+    it('should respect reporter options', done => {
+      let config = {
+        serviceName: 'test-service',
+        sampler: {
+          type: 'const',
+          param: 0,
+        },
+        reporter: {
+          logSpans: true,
+          agentHost: '127.0.0.1',
+          agentPort: 4939,
+          flushIntervalMs: 2000,
+        },
+      };
+      let tracer = initTracer(config);
 
-    expect(tracer._reporter).to.be.an.instanceof(CompositeReporter);
-    let remoteReporter;
-    for (let i = 0; i < tracer._reporter._reporters.length; i++) {
-      let reporter = tracer._reporter._reporters[i];
-      if (reporter instanceof RemoteReporter) {
-        remoteReporter = reporter;
-        break;
+      expect(tracer._reporter).to.be.an.instanceof(CompositeReporter);
+      let remoteReporter;
+      for (let i = 0; i < tracer._reporter._reporters.length; i++) {
+        let reporter = tracer._reporter._reporters[i];
+        if (reporter instanceof RemoteReporter) {
+          remoteReporter = reporter;
+          break;
+        }
       }
-    }
 
-    assert.equal(remoteReporter._bufferFlushInterval, 2000);
-    assert.equal(remoteReporter._sender._host, '127.0.0.1');
-    assert.equal(remoteReporter._sender._port, 4939);
-    tracer.close(done);
+      assert.equal(remoteReporter._bufferFlushInterval, 2000);
+      assert.equal(remoteReporter._sender._host, '127.0.0.1');
+      assert.equal(remoteReporter._sender._port, 4939);
+      assert.instanceOf(remoteReporter._sender, UDPSender);
+      tracer.close(done);
+    });
+
+    _.each(['http', 'https'], protocol => {
+      it(`should create an HTTPSender if protocol is ${protocol}`, done => {
+        let config = {
+          serviceName: 'test-service',
+          sampler: {
+            type: 'const',
+            param: 0,
+          },
+          reporter: {
+            logSpans: true,
+            agentProtocol: protocol,
+            agentHost: '127.0.0.1',
+            agentPort: 4939,
+            agentPath: '/my/path',
+            username: protocol === 'https' ? 'test' : undefined,
+            password: protocol === 'https' ? 'mypass' : undefined,
+            flushIntervalMs: 2000,
+          },
+        };
+        let tracer = initTracer(config);
+
+        expect(tracer._reporter).to.be.an.instanceof(CompositeReporter);
+        let remoteReporter;
+        for (let i = 0; i < tracer._reporter._reporters.length; i++) {
+          let reporter = tracer._reporter._reporters[i];
+          if (reporter instanceof RemoteReporter) {
+            remoteReporter = reporter;
+            break;
+          }
+        }
+
+        assert.equal(url.format(remoteReporter._sender._url), `${protocol}://127.0.0.1:4939/my/path`);
+        assert.instanceOf(remoteReporter._sender, HTTPSender);
+        tracer.close(done);
+      });
+    });
   });
 
   it('should pass options to tracer', done => {


### PR DESCRIPTION
This will use the Jaeger collector HTTP endpoint (assumed to be running
on localhost) by default, but is configurable to send Thrift-encoded
spans to any HTTP endpoint.

Spans are batched upto a certain amount (based on # of spans and not
byte lengths) and are also flushed on a regular interval by the
RemoteReporter just like with the UDPSender.

It also supports basic auth in case the Jaeger collector has some form
of authentication in front of it.

Fixes #170

Signed-off-by: Ben Keith <bkeith@signalfx.com>
