### PR TITLE
Rename 'throttler_update' metric to 'throttler_updates'

### DIFF
--- a/src/metrics/metrics.js
+++ b/src/metrics/metrics.js
@@ -113,7 +113,7 @@ export default class Metrics {
 
     this.throttledDebugSpans = this._factory.createCounter('jaeger:throttled_debug_spans');
 
-    this.throttlerUpdateSuccess = this._factory.createCounter('jaeger:throttler_update', {
+    this.throttlerUpdateSuccess = this._factory.createCounter('jaeger:throttler_updates', {
       result: 'ok',
     });
 


### PR DESCRIPTION
Signed-off-by: Won Jun Jang <wjang@uber.com>

## Which problem is this PR solving?
- Fix inconsistency seen here: https://github.com/jaegertracing/jaeger-client-node/pull/279/files#r209324272

No tests need to updated because we mock metrics, we would need to introduce a local metric store (maybe use prometheus?) to test against the actual metric.
