### PR TITLE
Swap https/http order

### DIFF
--- a/src/reporters/http_sender.js
+++ b/src/reporters/http_sender.js
@@ -47,9 +47,9 @@ export default class HTTPSender {
     this._password = options.password;
     this._timeoutMS = options.timeoutMS || DEFAULT_TIMEOUT_MS;
     this._httpAgent =
-      this._url.protocol === 'http:'
-        ? new http.Agent({ keepAlive: true })
-        : new https.Agent({ keepAlive: true });
+      this._url.protocol === 'https:'
+        ? new https.Agent({ keepAlive: true })
+        : new http.Agent({ keepAlive: true });
 
     this._maxSpanBatchSize = options.maxSpanBatchSize || DEFAULT_MAX_SPAN_BATCH_SIZE;
 


### PR DESCRIPTION
This feels more backwards compatible. Maybe `url.protocol == 'http'` is guaranteed, I don't know, but I would rather it fail when it's not https (meaning it's no worse than in the previous release) than fail for regular http.