### PR TITLE
Fix HTTPSender ignoring query parameters

### DIFF
--- a/src/reporters/http_sender.js
+++ b/src/reporters/http_sender.js
@@ -63,7 +63,7 @@ export default class HTTPSender {
       protocol: this._url.protocol,
       hostname: this._url.hostname,
       port: this._url.port,
-      path: this._url.pathname,
+      path: this._url.path,
       method: 'POST',
       auth: this._username && this._password ? `${this._username}:${this._password}` : undefined,
       headers: {


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #301 

## Short description of the changes

Changed HTTPSender to include query parameters from `collectorEndpoint`.
