### PR TITLE
Change Zipkin Codec to Not Inject Missing Parent

### DIFF
--- a/src/propagators/zipkin_b3_text_map_codec.js
+++ b/src/propagators/zipkin_b3_text_map_codec.js
@@ -155,7 +155,9 @@ export default class ZipkinB3TextMapCodec {
 
   inject(spanContext: SpanContext, carrier: any): void {
     carrier[ZIPKIN_TRACE_HEADER] = spanContext.traceIdStr;
-    carrier[ZIPKIN_PARENTSPAN_HEADER] = spanContext.parentIdStr;
+    if (spanContext.parentIdStr) {
+      carrier[ZIPKIN_PARENTSPAN_HEADER] = spanContext.parentIdStr;
+    }
     carrier[ZIPKIN_SPAN_HEADER] = spanContext.spanIdStr;
 
     if (spanContext.isDebug()) {

--- a/test/propagators.js
+++ b/test/propagators.js
@@ -95,6 +95,23 @@ describe('ZipkinB3TextMapCodec', () => {
     assert.equal(ctx.isSampled(), true);
     assert.equal(ctx.isDebug(), true);
   });
+  it('should not extract parentspanid if not injected', () => {
+    let codec = new ZipkinB3TextMapCodec({ urlEncoding: true });
+
+    let carrier = {
+      // do not specify parentspanid when extracting
+      // 'x-b3-parentspanid': '',
+      'x-b3-spanid': '0b42e8789a26ba03',
+      'x-b3-traceid': '0b42e8789a26ba03',
+      'x-b3-sampled': '1',
+      'x-b3-flags': '1',
+      foo: 'bar',
+    };
+    let ctx = codec.extract(carrier);
+    let injectedHeaders = {};
+    codec.inject(ctx, injectedHeaders);
+    assert.notProperty(injectedHeaders, 'x-b3-parentspanid');
+  });
   it('correctly inject the zipkin headers into a span context', () => {
     let codec = new ZipkinB3TextMapCodec({ urlEncoding: true });
     let carrier = {};


### PR DESCRIPTION
The Zipkin b3 TextMap codec was injecting an empty string for the
x-b3-parentspanid field when one was not present in the object it
extracted the SpanContext from. This caused gaps in the traces.

This change first checks the span context's parentIdStr value,
and does not inject it into the carrier if it is falsy.

Signed-off-by: Andrew DiNunzio <adinunzio84@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Resolves #304


## Short description of the changes
Checks the parentspanid to only inject into the carrier if it is not falsy in the SpanContext.
