### PR TITLE
Makes zipkin codec work with case insensitive headers.

### DIFF
--- a/src/propagators/zipkin_b3_text_map_codec.js
+++ b/src/propagators/zipkin_b3_text_map_codec.js
@@ -103,13 +103,13 @@ export default class ZipkinB3TextMapCodec {
 
         switch (lowerKey) {
           case ZIPKIN_PARENTSPAN_HEADER:
-            parentId = this._decodeValue(carrier[ZIPKIN_PARENTSPAN_HEADER]);
+            parentId = this._decodeValue(carrier[key]);
             break;
           case ZIPKIN_SPAN_HEADER:
-            spanId = this._decodeValue(carrier[ZIPKIN_SPAN_HEADER]);
+            spanId = this._decodeValue(carrier[key]);
             break;
           case ZIPKIN_TRACE_HEADER:
-            traceId = this._decodeValue(carrier[ZIPKIN_TRACE_HEADER]);
+            traceId = this._decodeValue(carrier[key]);
             break;
           case ZIPKIN_SAMPLED_HEADER:
             flags = flags | constants.SAMPLED_MASK;
@@ -124,7 +124,7 @@ export default class ZipkinB3TextMapCodec {
             }
             break;
           case constants.JAEGER_DEBUG_HEADER:
-            debugId = this._decodeValue(carrier[constants.JAEGER_DEBUG_HEADER]);
+            debugId = this._decodeValue(carrier[key]);
             break;
           case constants.JAEGER_BAGGAGE_HEADER:
             parseCommaSeparatedBaggage(baggage, this._decodeValue(carrier[key]));

--- a/test/zipkin_b3_text_map_codec.js
+++ b/test/zipkin_b3_text_map_codec.js
@@ -92,6 +92,30 @@ describe('Zipkin B3 Text Map Codec should', () => {
     });
   });
 
+  it("should normalize header's case and return a context", () => {
+    /**
+     *  HTTP headers are case insensitive and title case is often used, e.g.:
+     *  X-B3-TraceId.
+     */
+    const headers = {
+      'X-B3-TraceId': '123abc',
+      'x-b3-spanID': '456def',
+      'X-B3-PARENTSPANID': '789ghi',
+      'X-b3-SAmpleD': '012jkl',
+      'X-b3-Flags': '1',
+      'Jaeger-Debug-ID': '678pqr',
+    };
+
+    const context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
+
+    assert.isOk(context.traceIdStr);
+    assert.isOk(context.spanIdStr);
+    assert.isOk(context.parentIdStr);
+    assert.isOk(context.isSampled());
+    assert.isOk(context.isDebug());
+    assert.isOk(context.debugId);
+  });
+
   it('set the sampled flag when the zipkin sampled header is received', () => {
     let headers = {
       'x-b3-sampled': '1',


### PR DESCRIPTION
## Which problem is this PR solving?

Since HTTP headers are case insensitive and title case is often used,
If we have a carrier that has **not** lower case B3 Zipkin headers - we'll get an `undefined` value or a `TypeError`.

E.g.:

```js
const carrier = {
  'X-B3-TraceId': '123456',
  // ...
};

// extract the context
const context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
```
Here lower case name for the `TraceId` B3 header will match the `ZIPKIN_TRACE_HEADER` constant
but the carrier doesn't actually have `carrier[ZIPKIN_TRACE_HEADER]` key.

This will lead to the following unexpected behavior:

- if `urlEncoding` is set to `false` - `context.traceId` getter will be `undefined`;
- if `urlEncoding` is set to `true` - `context.traceId` getter will throw `TypeError: Cannot read property 'indexOf' of undefined` .

https://github.com/jaegertracing/jaeger-client-node/blob/9b1e1ffec1a3b87d70265b7b09aa312712c416c5/src/propagators/zipkin_b3_text_map_codec.js#L47:L54

## Short description of the changes

`zipkin_b3_text_map_codec` is always using original carrier's keys and not their lower case names.



