### PR TITLE
Allowes to override codec's default baggage prefix.

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -226,6 +226,7 @@ export default class Configuration {
 
     return new Tracer(config.serviceName, reporter, sampler, {
       contextKey: options.contextKey,
+      baggagePrefix: options.baggagePrefix,
       metrics: options.metrics,
       logger: options.logger,
       tags: options.tags,

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -55,6 +55,7 @@ export default class Tracer {
    * @param {Object} [options.logger] - a logger matching NullLogger API from ./logger.js.
    * @param {Object} [options.baggageRestrictionManager] - a baggageRestrictionManager matching
    * @param {Object} [options.contextKey] - a name of the key to extract/inject context from headers
+   * @param {Object} [options.baggagePrefix] - a name of the context baggage key prefix
    * BaggageRestrictionManager API from ./baggage.js.
    */
   constructor(
@@ -84,6 +85,7 @@ export default class Tracer {
 
     let codecOptions = {
       contextKey: options.contextKey || null,
+      baggagePrefix: options.baggagePrefix || null,
       urlEncoding: false,
       metrics: this._metrics,
     };

--- a/test/init_tracer.js
+++ b/test/init_tracer.js
@@ -210,12 +210,16 @@ describe('initTracer', () => {
           x: 'y',
         },
         contextKey: 'custom-header',
+        baggagePrefix: 'prfx-',
       }
     );
     assert.equal(tracer._logger, logger);
     assert.equal(tracer._metrics._factory, metrics);
     assert.equal(tracer._tags['x'], 'y');
-    assert.equal(tracer._injectors[opentracing.FORMAT_TEXT_MAP]._contextKey, 'custom-header');
+
+    const textMapInjector = tracer._injectors[opentracing.FORMAT_TEXT_MAP];
+    assert.equal(textMapInjector._contextKey, 'custom-header');
+    assert.equal(textMapInjector._baggagePrefix, 'prfx-');
     tracer.close(done);
   });
 


### PR DESCRIPTION
Signed-off-by: Artem Ruts <aruts@wayfair.com>

## Which problem is this PR solving?

Tracer can be configured to override codec's default `TRACER_BAGGAGE_HEADER_PREFIX` baggage prefix constant.

## Short description of the changes

Passes `baggagePrefix` override from `configuration.js` `initTracer`'s options to codec constructors in `tracer.js`
