### PR TITLE
fix Span.log returns this

### DIFF
--- a/src/span.js
+++ b/src/span.js
@@ -253,14 +253,16 @@ export default class Span {
    *        timestamps with sub-millisecond accuracy can be represented. If
    *        not specified, the implementation is expected to use its notion
    *        of the current time of the call.
+   * @return {Span} - returns this span.
    */
-  log(keyValuePairs: any, timestamp: ?number): void {
+  log(keyValuePairs: any, timestamp: ?number): Span {
     if (this._isWriteable()) {
       this._logs.push({
         timestamp: timestamp || this._tracer.now(),
         fields: Utils.convertObjectToTags(keyValuePairs),
       });
     }
+    return this;
   }
 
   /**

--- a/test/span.js
+++ b/test/span.js
@@ -76,6 +76,11 @@ describe('span should', () => {
     assert.equal(tracer._logger._errorMsgs[0], `${spanInfo}#You can only call finish() on a span once.`);
   });
 
+  it('return this when calling log method', () => {
+    const ret = span.log({ event: event }, timestamp);
+    assert.equal(ret, span);
+  });
+
   it('set debug and sampling version through sampling priority', () => {
     span._setSamplingPriority(3);
 


### PR DESCRIPTION
Signed-off-by: Charles-Edouard Breteche <doubret@yahoo.co.uk>

Resolves #312

fix Span.log should return this
added test to check span.log returns the span itself