### PR TITLE
Support injecting and extracting into carriers without Object prototypes

### DIFF
--- a/src/propagators/text_map_codec.js
+++ b/src/propagators/text_map_codec.js
@@ -65,7 +65,7 @@ export default class TextMapCodec {
     let debugId = '';
 
     for (let key in carrier) {
-      if (carrier.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(carrier, key)) {
         let lowerKey = key.toLowerCase();
         if (lowerKey === this._contextKey) {
           let decodedContext = SpanContext.fromString(this._decodeValue(carrier[key]));
@@ -96,7 +96,7 @@ export default class TextMapCodec {
 
     let baggage = spanContext.baggage;
     for (let key in baggage) {
-      if (baggage.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(baggage, key)) {
         let value = this._encodeValue(spanContext.baggage[key]);
         carrier[`${this._baggagePrefix}${key}`] = value;
       }

--- a/src/propagators/zipkin_b3_text_map_codec.js
+++ b/src/propagators/zipkin_b3_text_map_codec.js
@@ -98,7 +98,7 @@ export default class ZipkinB3TextMapCodec {
     let traceId = '';
 
     for (let key in carrier) {
-      if (carrier.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(carrier, key)) {
         let lowerKey = key.toLowerCase();
 
         switch (lowerKey) {
@@ -171,7 +171,7 @@ export default class ZipkinB3TextMapCodec {
 
     let baggage = spanContext.baggage;
     for (let key in baggage) {
-      if (baggage.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(baggage, key)) {
         let value = this._encodeValue(spanContext.baggage[key]);
         carrier[`${this._baggagePrefix}${key}`] = value;
       }

--- a/src/span.js
+++ b/src/span.js
@@ -209,7 +209,7 @@ export default class Span {
     const samplingPriorityWasSet = samplingPriority != null && this._setSamplingPriority(samplingPriority);
     if (this._isWriteable()) {
       for (let key in keyValuePairs) {
-        if (keyValuePairs.hasOwnProperty(key)) {
+        if (Object.prototype.hasOwnProperty.call(keyValuePairs, key)) {
           if (key === samplingKey && !samplingPriorityWasSet) {
             continue;
           }

--- a/src/tchannel_bridge.js
+++ b/src/tchannel_bridge.js
@@ -103,7 +103,10 @@ export default class TChannelBridge {
       let headerKeys: Array<string> = Object.keys(headers);
       for (let i = 0; i < headerKeys.length; i++) {
         let key = headerKeys[i];
-        if (headers.hasOwnProperty(key) && Utils.startsWith(key, TCHANNEL_TRACING_PREFIX)) {
+        if (
+          Object.prototype.hasOwnProperty.call(headers, key) &&
+          Utils.startsWith(key, TCHANNEL_TRACING_PREFIX)
+        ) {
           delete headers[key];
         }
       }

--- a/src/test_util.js
+++ b/src/test_util.js
@@ -25,7 +25,10 @@ export default class TestUtils {
     }
 
     for (let tag in expectedTags) {
-      if (expectedTags.hasOwnProperty(tag) && actualTags.hasOwnProperty(tag)) {
+      if (
+        Object.prototype.hasOwnProperty.call(expectedTags, tag) &&
+        Object.prototype.hasOwnProperty.call(actualTags, tag)
+      ) {
         if (actualTags[tag] !== expectedTags[tag]) {
           console.log('expected tag:', expectedTags[tag], ', actual tag: ', actualTags[tag]);
           return false;

--- a/src/util.js
+++ b/src/util.js
@@ -125,7 +125,7 @@ export default class Utils {
   static clone(obj: any): any {
     let newObj = {};
     for (let key in obj) {
-      if (obj.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
         newObj[key] = obj[key];
       }
     }
@@ -137,7 +137,7 @@ export default class Utils {
     let tags: Array<Tag> = [];
     for (let key in dict) {
       let value = dict[key];
-      if (dict.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(dict, key)) {
         tags.push({ key: key, value: value });
       }
     }

--- a/test/tracer.js
+++ b/test/tracer.js
@@ -216,6 +216,27 @@ describe('tracer should', () => {
     });
   });
 
+  it('inject and extract headers from carriers without Object prototypes', () => {
+    let ck = 'test-trace-id';
+    let mytracer = new Tracer('test-service-name', reporter, new ConstSampler(true), {
+      contextKey: ck,
+    });
+
+    let headers = Object.create(null);
+    headers[ck] = 'a:b:c:d';
+
+    let mycontext = mytracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
+    assert.equal(mycontext.toString(), headers[ck]);
+
+    let myspan = mytracer.startSpan('myspan', { childOf: mycontext });
+    assert.equal(myspan.context().traceIdStr, 'a');
+
+    let exheaders = Object.create(null);
+
+    mytracer.inject(myspan.context(), opentracing.FORMAT_HTTP_HEADERS, exheaders);
+    assert.notEqual(exheaders[ck], null);
+  });
+
   it('inject plain text headers into carrier, and extract span context with the same value', () => {
     let keyOne = 'keyOne';
     let keyTwo = 'keyTwo';


### PR DESCRIPTION
Signed-off-by: Geoffrey Goodman <ggoodman@gmail.com>

## Which problem is this PR solving?

Resolves #317

## Short description of the changes

Changes calls that expect different user-supplied objects to be prototypical objects to more defensive calls using `Object.prototype.hasOwnProperty.call`.
