### PR TITLE
Mismatching env variables

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -36,6 +36,7 @@ let jaegerSchema = {
       properties: {
         type: { type: 'string' },
         param: { type: 'number' },
+        hostPort: { type: 'string' },
         host: { type: 'string' },
         port: { type: 'number' },
         refreshIntervalMs: { type: 'number' },
@@ -70,6 +71,7 @@ export default class Configuration {
   static _getSampler(config, options) {
     let type = config.sampler.type;
     let param = config.sampler.param;
+    let hostPort = config.sampler.hostPort;
     let host = config.sampler.host;
     let port = config.sampler.port;
     let refreshIntervalMs = config.sampler.refreshIntervalMs;
@@ -94,6 +96,7 @@ export default class Configuration {
     if (type === constants.SAMPLER_TYPE_REMOTE) {
       sampler = new RemoteSampler(config.serviceName, {
         sampler: new ProbabilisticSampler(param),
+        hostPort: hostPort,
         host: host,
         port: port,
         refreshInterval: refreshIntervalMs,

--- a/src/configuration_env.js
+++ b/src/configuration_env.js
@@ -30,6 +30,15 @@ export default class ConfigurationEnv {
       samplerConfig.param = parseFloat(value);
     }
 
+    value = ConfigurationEnv._getConfigValue(
+      config.sampler,
+      'hostPort',
+      process.env.JAEGER_SAMPLER_MANAGER_HOST_PORT
+    );
+    if (value) {
+      samplerConfig.hostPort = value;
+    }
+
     value = ConfigurationEnv._getConfigValue(config.sampler, 'host', process.env.JAEGER_SAMPLER_HOST);
     if (value) {
       samplerConfig.host = value;

--- a/src/configuration_env.js
+++ b/src/configuration_env.js
@@ -75,13 +75,17 @@ export default class ConfigurationEnv {
     value = ConfigurationEnv._getConfigValue(
       config.reporter,
       'collectorEndpoint',
-      process.env.JAEGER_REPORTER_ENDPOINT
+      process.env.JAEGER_ENDPOINT || process.env.JAEGER_REPORTER_ENDPOINT
     );
     if (value) {
       reporterConfig.collectorEndpoint = value;
     }
 
-    value = ConfigurationEnv._getConfigValue(config.reporter, 'username', process.env.JAEGER_REPORTER_USER);
+    value = ConfigurationEnv._getConfigValue(
+      config.reporter,
+      'username',
+      process.env.JAEGER_USER || process.env.JAEGER_REPORTER_USER
+    );
     if (value) {
       reporterConfig.username = value;
     }
@@ -89,7 +93,7 @@ export default class ConfigurationEnv {
     value = ConfigurationEnv._getConfigValue(
       config.reporter,
       'password',
-      process.env.JAEGER_REPORTER_PASSWORD
+      process.env.JAEGER_PASSWORD || process.env.JAEGER_REPORTER_PASSWORD
     );
     if (value) {
       reporterConfig.password = value;
@@ -98,7 +102,7 @@ export default class ConfigurationEnv {
     value = ConfigurationEnv._getConfigValue(
       config.reporter,
       'agentHost',
-      process.env.JAEGER_REPORTER_AGENT_HOST
+      process.env.JAEGER_AGENT_HOST || process.env.JAEGER_REPORTER_AGENT_HOST
     );
     if (value) {
       reporterConfig.agentHost = value;
@@ -107,7 +111,7 @@ export default class ConfigurationEnv {
     value = ConfigurationEnv._getConfigValue(
       config.reporter,
       'agentPort',
-      process.env.JAEGER_REPORTER_AGENT_PORT
+      process.env.JAEGER_AGENT_PORT || process.env.JAEGER_REPORTER_AGENT_PORT
     );
     if (value) {
       reporterConfig.agentPort = parseInt(value);

--- a/test/init_tracer.js
+++ b/test/init_tracer.js
@@ -299,6 +299,7 @@ describe('initTracerFromENV', () => {
     delete process.env.JAEGER_SAMPLER_PARAM;
     delete process.env.JAEGER_SAMPLER_HOST;
     delete process.env.JAEGER_SAMPLER_PORT;
+    delete process.env.JAEGER_SAMPLER_MANAGER_HOST_PORT;
     delete process.env.JAEGER_SAMPLER_REFRESH_INTERVAL;
     delete process.env.JAEGER_REPORTER_AGENT_PORT;
     delete process.env.JAEGER_AGENT_PORT;
@@ -353,6 +354,27 @@ describe('initTracerFromENV', () => {
   });
 
   it('should initialize proper samplers from env', () => {
+    process.env.JAEGER_SERVICE_NAME = 'test-service';
+
+    process.env.JAEGER_SAMPLER_TYPE = 'probabilistic';
+    process.env.JAEGER_SAMPLER_PARAM = 0.5;
+    let tracer = initTracerFromEnv();
+    expect(tracer._sampler).to.be.an.instanceof(ProbabilisticSampler);
+    assert.equal(tracer._sampler._samplingRate, 0.5);
+    tracer.close();
+
+    process.env.JAEGER_SAMPLER_TYPE = 'remote';
+    process.env.JAEGER_SAMPLER_MANAGER_HOST_PORT = 'localhost:8080';
+    process.env.JAEGER_SAMPLER_REFRESH_INTERVAL = 100;
+    tracer = initTracerFromEnv();
+    expect(tracer._sampler).to.be.an.instanceof(RemoteSampler);
+    assert.equal(tracer._sampler._host, 'localhost');
+    assert.equal(tracer._sampler._port, 8080);
+    assert.equal(tracer._sampler._refreshInterval, 100);
+    tracer.close();
+  });
+
+  it('should initialize proper samplers from mismatching env', () => {
     process.env.JAEGER_SERVICE_NAME = 'test-service';
 
     process.env.JAEGER_SAMPLER_TYPE = 'probabilistic';

--- a/test/init_tracer.js
+++ b/test/init_tracer.js
@@ -301,10 +301,15 @@ describe('initTracerFromENV', () => {
     delete process.env.JAEGER_SAMPLER_PORT;
     delete process.env.JAEGER_SAMPLER_REFRESH_INTERVAL;
     delete process.env.JAEGER_REPORTER_AGENT_PORT;
+    delete process.env.JAEGER_AGENT_PORT;
     delete process.env.JAEGER_REPORTER_AGENT_HOST;
+    delete process.env.JAEGER_AGENT_HOST;
     delete process.env.JAEGER_REPORTER_ENDPOINT;
+    delete process.env.JAEGER_ENDPOINT;
     delete process.env.JAEGER_REPORTER_USER;
+    delete process.env.JAEGER_USER;
     delete process.env.JAEGER_REPORTER_PASSWORD;
+    delete process.env.JAEGER_PASSWORD;
     delete process.env.JAEGER_REPORTER_FLUSH_INTERVAL;
     delete process.env.JAEGER_REPORTER_LOG_SPANS;
   });
@@ -372,6 +377,32 @@ describe('initTracerFromENV', () => {
   it('should respect udp reporter options from env', done => {
     process.env.JAEGER_SERVICE_NAME = 'test-service';
     process.env.JAEGER_REPORTER_LOG_SPANS = 'true';
+    process.env.JAEGER_AGENT_HOST = '127.0.0.1';
+    process.env.JAEGER_AGENT_PORT = 4939;
+    process.env.JAEGER_REPORTER_FLUSH_INTERVAL = 2000;
+
+    let tracer = initTracerFromEnv();
+    expect(tracer._reporter).to.be.an.instanceof(CompositeReporter);
+    let remoteReporter;
+    for (let i = 0; i < tracer._reporter._reporters.length; i++) {
+      let reporter = tracer._reporter._reporters[i];
+      if (reporter instanceof RemoteReporter) {
+        remoteReporter = reporter;
+        break;
+      }
+    }
+
+    assert.equal(remoteReporter._bufferFlushInterval, 2000);
+    assert.equal(remoteReporter._sender._host, '127.0.0.1');
+    assert.equal(remoteReporter._sender._port, 4939);
+    assert.instanceOf(remoteReporter._sender, UDPSender);
+
+    tracer.close(done);
+  });
+
+  it('should respect udp reporter options from mismatching env', done => {
+    process.env.JAEGER_SERVICE_NAME = 'test-service';
+    process.env.JAEGER_REPORTER_LOG_SPANS = 'true';
     process.env.JAEGER_REPORTER_AGENT_HOST = '127.0.0.1';
     process.env.JAEGER_REPORTER_AGENT_PORT = 4939;
     process.env.JAEGER_REPORTER_FLUSH_INTERVAL = 2000;
@@ -396,6 +427,24 @@ describe('initTracerFromENV', () => {
   });
 
   it('should respect http reporter options from env', done => {
+    process.env.JAEGER_SERVICE_NAME = 'test-service';
+    process.env.JAEGER_REPORTER_FLUSH_INTERVAL = 3000;
+    process.env.JAEGER_ENDPOINT = 'http://127.0.0.1:8080';
+    process.env.JAEGER_USER = 'test';
+    process.env.JAEGER_PASSWORD = 'xxxx';
+
+    let tracer = initTracerFromEnv();
+    expect(tracer._reporter).to.be.an.instanceof(RemoteReporter);
+    assert.instanceOf(tracer._reporter._sender, HTTPSender);
+    assert.equal(tracer._reporter._bufferFlushInterval, 3000);
+    assert.equal(tracer._reporter._sender._url.href, 'http://127.0.0.1:8080/');
+    assert.equal(tracer._reporter._sender._username, 'test');
+    assert.equal(tracer._reporter._sender._password, 'xxxx');
+
+    tracer.close(done);
+  });
+
+  it('should respect http reporter options from mismatching env', done => {
     process.env.JAEGER_SERVICE_NAME = 'test-service';
     process.env.JAEGER_REPORTER_FLUSH_INTERVAL = 3000;
     process.env.JAEGER_REPORTER_ENDPOINT = 'http://127.0.0.1:8080';


### PR DESCRIPTION
Support common env variables instead of mismatching variables.
Doc: https://www.jaegertracing.io/docs/1.8/client-features/
Fixes issue: #313 
Outdated PR: #311 