### PR TITLE
Make TchannelBridge use semantic conventions when logging error to the span

### DIFF
--- a/src/tchannel_bridge.js
+++ b/src/tchannel_bridge.js
@@ -65,7 +65,10 @@ export default class TChannelBridge {
   _tchannelCallbackWrapper(span: Span, callback: Function, err: any, res: any) {
     if (err) {
       span.setTag(opentracing.Tags.ERROR, true);
-      span.log('error_msg', err);
+      span.log({
+        event: 'error',
+        message: err,
+      });
     }
 
     span.finish();

--- a/test/tchannel_bridge.js
+++ b/test/tchannel_bridge.js
@@ -157,4 +157,61 @@ describe('test tchannel span bridge', () => {
       }
     }).timeout(BIG_TIMEOUT);
   });
+
+  let errSpanOptions = {
+    as: 'json',
+    mode: 'req.send',
+    context: ctx1,
+    headers: {},
+  };
+
+  it('as=json|mode=req.send spans log an error while propagating through tchannel', done => {
+    let server = new TChannel({
+      serviceName: 'server',
+      timeout: BIG_TIMEOUT,
+      trace: true,
+      forceTrace: true,
+    });
+    server.listen(4040, '127.0.0.1', onServerListeningErr);
+
+    let client = new TChannel({
+      trace: true,
+      forceTrace: true,
+    });
+
+    let clientSubChannel = client.makeSubChannel({
+      serviceName: 'server',
+      peers: ['127.0.0.1:4040'],
+    });
+
+    let encodedChannel = TChannelAsJSON({
+      channel: clientSubChannel,
+      entryPoint: path.join(__dirname, 'thrift', 'echo.thrift'),
+    });
+
+    let options: any = {};
+    encodedChannel.register(server, 'Echo::echo', options, bridge.tracedHandler(handleErrServerReq));
+    function handleErrServerReq(context, req, head, body, callback) {
+      callback('Some error occurred while propagation', { ok: false, body: {} });
+    }
+
+    function onServerListeningErr(err, res, arg2, arg3) {
+      let tracedChannel = bridge.tracedChannel(encodedChannel);
+      let clientCallback = (err, res, headers, body) => {
+        assert.isOk(err);
+        reporter.clear();
+        server.close();
+        client.close();
+        done();
+      };
+
+      let req = tracedChannel.request({
+        serviceName: 'server',
+        headers: { cn: 'echo' },
+        context: errSpanOptions.context,
+        timeout: BIG_TIMEOUT,
+      });
+      req.send('Echo::echo', errSpanOptions.headers, { value: 'some-string' }, clientCallback);
+    }
+  }).timeout(BIG_TIMEOUT);
 });


### PR DESCRIPTION
Signed-off-by: Varsha <varsha.verma.eee15@itbhu.ac.in>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fixes #251 

## Short description of the changes
- event and message key value pairs added in accordance with the opentracing conventions
