### PR TITLE
Transform IP from int32 representation to dot representation

### DIFF
--- a/src/tracer.js
+++ b/src/tracer.js
@@ -67,7 +67,7 @@ export default class Tracer {
     this._tags[constants.JAEGER_CLIENT_VERSION_TAG_KEY] = 'Node-3.14.4';
     this._tags[constants.TRACER_HOSTNAME_TAG_KEY] =
       this._tags[constants.TRACER_HOSTNAME_TAG_KEY] || os.hostname();
-    this._tags[constants.PROCESS_IP] = Utils.ipToInt(this._tags[constants.PROCESS_IP] || Utils.myIp());
+    this._tags[constants.PROCESS_IP] = this._tags[constants.PROCESS_IP] || Utils.myIp();
 
     this._metrics = options.metrics || new Metrics(new NoopMetricFactory());
 

--- a/src/util.js
+++ b/src/util.js
@@ -65,30 +65,6 @@ export default class Utils {
   }
 
   /**
-   * @param {string} ip - a string representation of an ip address.
-   * @return {number} - a 32-bit number where each byte represents an
-   * octect of an ip address.
-   **/
-  static ipToInt(ip: string): ?number {
-    let ipl = 0;
-    let parts = ip.split('.');
-    if (parts.length != 4) {
-      return null;
-    }
-
-    for (let i = 0; i < parts.length; i++) {
-      ipl <<= 8;
-      ipl += parseInt(parts[i], 10);
-    }
-
-    let signedLimit = 0x7fffffff;
-    if (ipl > signedLimit) {
-      return (1 << 32) - ipl;
-    }
-    return ipl;
-  }
-
-  /**
    * @param {string} input - the input for which leading zeros should be removed.
    * @return {string} - returns the input string without leading zeros.
    **/

--- a/test/tracer.js
+++ b/test/tracer.js
@@ -62,7 +62,7 @@ describe('tracer should', () => {
   });
 
   it('find the ip and hostname by default', () => {
-    assert.equal(tracer._tags[constants.PROCESS_IP], Utils.ipToInt(Utils.myIp()));
+    assert.equal(tracer._tags[constants.PROCESS_IP], Utils.myIp());
     assert.equal(tracer._tags[constants.TRACER_HOSTNAME_TAG_KEY], os.hostname());
   });
 
@@ -74,7 +74,7 @@ describe('tracer should', () => {
       tags: mytags,
     });
 
-    assert.equal(mytracer._tags[constants.PROCESS_IP], Utils.ipToInt('10.0.0.1'));
+    assert.equal(mytracer._tags[constants.PROCESS_IP], '10.0.0.1');
     assert.equal(mytracer._tags[constants.TRACER_HOSTNAME_TAG_KEY], '10.0.0.1.internal');
   });
 

--- a/test/util.js
+++ b/test/util.js
@@ -16,20 +16,6 @@ import Utils from '../src/util.js';
 import combinations from './lib/combinations.js';
 
 describe('utils', () => {
-  describe('ipToInt', () => {
-    it('should convert malformed IP to null', () => {
-      assert.isNotOk(Utils.ipToInt('127.0'));
-    });
-
-    it('should convert an ip less than 2^32 to an unsigned number', () => {
-      assert.equal((127 << 24) | 1, Utils.ipToInt('127.0.0.1'));
-    });
-
-    it('should convert an ip greater than 2^32 to a negative number', () => {
-      assert.equal(-1, Utils.ipToInt('255.255.255.255'));
-    });
-  });
-
   describe('removeLeadingZeros', () => {
     it('should leave single 0 digit intact', () => {
       assert.equal('0', Utils.removeLeadingZeros('0'));


### PR DESCRIPTION
## Which problem is this PR solving?
- Standardize process.ip field . After discussion on mailinglist (https://groups.google.com/forum/#!topic/jaeger-tracing/T7pIa_jkcaU), the node client will send ip in dot format and not in signed int32. 
