### PR TITLE
Support false values for the B3 Sampled header

### DIFF
--- a/src/propagators/zipkin_b3_text_map_codec.js
+++ b/src/propagators/zipkin_b3_text_map_codec.js
@@ -112,7 +112,9 @@ export default class ZipkinB3TextMapCodec {
             traceId = this._decodeValue(carrier[key]);
             break;
           case ZIPKIN_SAMPLED_HEADER:
-            flags = flags | constants.SAMPLED_MASK;
+            if (carrier[key] === '1' || carrier[key] === 'true') {
+              flags = flags | constants.SAMPLED_MASK;
+            }
             break;
           case ZIPKIN_FLAGS_HEADER:
             // Per https://github.com/openzipkin/b3-propagation

--- a/test/zipkin_b3_text_map_codec.js
+++ b/test/zipkin_b3_text_map_codec.js
@@ -126,6 +126,33 @@ describe('Zipkin B3 Text Map Codec should', () => {
     assert.isNotOk(context.isDebug());
   });
 
+  it('not set the sampled flag if sampling is denied', () => {
+    const headers = {
+      'x-b3-sampled': '0',
+    };
+
+    const context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
+    assert.isNotOk(context.isSampled());
+  });
+
+  it('handle true value for the sampled header', () => {
+    let headers = {
+      'x-b3-sampled': 'true',
+    };
+
+    let context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
+    assert.isOk(context.isSampled());
+  });
+
+  it('handle false value for the sampled header', () => {
+    let headers = {
+      'x-b3-sampled': 'false',
+    };
+
+    let context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
+    assert.isNotOk(context.isSampled());
+  });
+
   it('set the debug and sampled flags when the zipkin flags header is received', () => {
     let headers = {
       'x-b3-flags': '1',


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
The sampling state headers can have three possible values; force sampling, deny sampling, and defer sampling decision. The B3 propagator only looks at the existence of the header, and thus always forces sampling, even when the value is falsy.

> An accept sampling decision is encoded as `X-B3-Sampled: 1` and a deny as `X-B3-Sampled: 0`. Absent means defer the decision to the receiver of this header. For example, a Sampled header might look like: `X-B3-Sampled: 1`.
> 
> Note: Before this specification was written, some tracers propagated `X-B3-Sampled` as `true` or `false` as opposed to `1` or `0`. While you shouldn't encode `X-B3-Sampled` as `true` or `false`, a lenient implementation may accept them.

https://github.com/openzipkin/b3-propagation#sampling-state-1

## Short description of the changes

Check that the value is true before setting the sampling flag.
