### PR TITLE
Update make build-node to feed version to src/tracer.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,11 @@ check-node-6:
 
 .PHONY: build-node
 build-node: check-node-6 node-modules
-	sed -i.bak "s|module.exports = '.*'|module.exports = '$(shell node -p 'require("./package.json").version')'|" src/version.js && rm src/version.js.bak
 	rm -rf ./dist/
 	node_modules/.bin/babel --presets env --plugins transform-class-properties --source-maps -d dist/src/ src/
 	node_modules/.bin/babel --presets env --plugins transform-class-properties --source-maps -d dist/test/ test/
 	node_modules/.bin/babel --presets env --plugins transform-class-properties --source-maps -d dist/crossdock/ crossdock/
+	cat src/version.js | sed "s|VERSION_TBD|$(shell node -p 'require("./package.json").version')|g" > dist/src/version.js
 	cp -R ./test/thrift ./dist/test/thrift/
 	cp package.json ./dist/
 	cp -R ./src/jaeger-idl ./dist/src/

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ check-node-6:
 
 .PHONY: build-node
 build-node: check-node-6 node-modules
-	sed -i.bak "s|const pjsonVersion = '.*'|const pjsonVersion = '$(shell node -p 'require("./package.json").version')'|" src/tracer.js && rm src/tracer.js.bak
+	sed -i.bak "s|module.exports = '.*'|module.exports = '$(shell node -p 'require("./package.json").version')'|" src/version.js && rm src/version.js.bak
 	rm -rf ./dist/
 	node_modules/.bin/babel --presets env --plugins transform-class-properties --source-maps -d dist/src/ src/
 	node_modules/.bin/babel --presets env --plugins transform-class-properties --source-maps -d dist/test/ test/

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ check-node-6:
 
 .PHONY: build-node
 build-node: check-node-6 node-modules
+	sed -i.bak "s|const pjsonVersion = '.*'|const pjsonVersion = '$(shell node -p 'require("./package.json").version')'|" src/tracer.js && rm src/tracer.js.bak
 	rm -rf ./dist/
 	node_modules/.bin/babel --presets env --plugins transform-class-properties --source-maps -d dist/src/ src/
 	node_modules/.bin/babel --presets env --plugins transform-class-properties --source-maps -d dist/test/ test/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,7 +31,6 @@ Declaring formal releases requires peer review.
     * Follow these instructions to create a token: https://docs.npmjs.com/getting-started/working_with_tokens
 * Create a "Back to development" pull request
   * Increment patch number in [package.json](./package.json) with `dev` suffix, e.g. if the last release was `3.5.3` then change it to `3.5.4dev`
-  * Update [src/version.js](./src/version.js) to reflect the version in package.json
   * Add a new entry to [CHANGELOG.md](./CHANGELOG.md)
     * Caption `{next_version} (unreleased)`
     * In place of the list of changes, add one entry "- nothing yet"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,6 +31,7 @@ Declaring formal releases requires peer review.
     * Follow these instructions to create a token: https://docs.npmjs.com/getting-started/working_with_tokens
 * Create a "Back to development" pull request
   * Increment patch number in [package.json](./package.json) with `dev` suffix, e.g. if the last release was `3.5.3` then change it to `3.5.4dev`
+  * Update [src/version.js](./src/version.js) to reflect the version in package.json
   * Add a new entry to [CHANGELOG.md](./CHANGELOG.md)
     * Caption `{next_version} (unreleased)`
     * In place of the list of changes, add one entry "- nothing yet"

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -29,8 +29,7 @@ import os from 'os';
 import BaggageSetter from './baggage/baggage_setter';
 import DefaultThrottler from './throttler/default_throttler';
 import uuidv4 from 'uuid/v4';
-
-const pjsonVersion = '3.14.4';
+import version from './version';
 
 export default class Tracer {
   _serviceName: string;
@@ -66,7 +65,7 @@ export default class Tracer {
     options: any = {}
   ) {
     this._tags = options.tags || {};
-    this._tags[constants.JAEGER_CLIENT_VERSION_TAG_KEY] = `Node-${pjsonVersion}`;
+    this._tags[constants.JAEGER_CLIENT_VERSION_TAG_KEY] = `Node-${version}`;
     this._tags[constants.TRACER_HOSTNAME_TAG_KEY] =
       this._tags[constants.TRACER_HOSTNAME_TAG_KEY] || os.hostname();
     this._tags[constants.PROCESS_IP] = this._tags[constants.PROCESS_IP] || Utils.myIp();

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -30,6 +30,8 @@ import BaggageSetter from './baggage/baggage_setter';
 import DefaultThrottler from './throttler/default_throttler';
 import uuidv4 from 'uuid/v4';
 
+const pjsonVersion = '3.14.4';
+
 export default class Tracer {
   _serviceName: string;
   _reporter: Reporter;
@@ -64,7 +66,7 @@ export default class Tracer {
     options: any = {}
   ) {
     this._tags = options.tags || {};
-    this._tags[constants.JAEGER_CLIENT_VERSION_TAG_KEY] = 'Node-3.14.4';
+    this._tags[constants.JAEGER_CLIENT_VERSION_TAG_KEY] = `Node-${pjsonVersion}`;
     this._tags[constants.TRACER_HOSTNAME_TAG_KEY] =
       this._tags[constants.TRACER_HOSTNAME_TAG_KEY] || os.hostname();
     this._tags[constants.PROCESS_IP] = this._tags[constants.PROCESS_IP] || Utils.myIp();

--- a/src/version.js
+++ b/src/version.js
@@ -1,0 +1,13 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+module.exports = '3.14.4';

--- a/src/version.js
+++ b/src/version.js
@@ -10,4 +10,4 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-module.exports = '3.14.4';
+module.exports = 'VERSION_TBD';


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #338 
- Makefile creates dist/src/tracer.js with version from package.json instead of a hardcoded value.

## Short description of the changes
- Add src/version.js with stand in version.
- Change the version in dist/src/version.js to be version from package.json.