### PR TITLE
Avoid mutation of user's tags

### DIFF
--- a/src/tracer.js
+++ b/src/tracer.js
@@ -63,7 +63,7 @@ export default class Tracer {
     sampler: Sampler = new ConstSampler(false),
     options: any = {}
   ) {
-    this._tags = options.tags || {};
+    this._tags = options.tags ? Utils.clone(options.tags) : {};
     this._tags[constants.JAEGER_CLIENT_VERSION_TAG_KEY] = 'Node-3.14.4';
     this._tags[constants.TRACER_HOSTNAME_TAG_KEY] =
       this._tags[constants.TRACER_HOSTNAME_TAG_KEY] || os.hostname();

--- a/test/tracer.js
+++ b/test/tracer.js
@@ -417,4 +417,18 @@ describe('tracer should', () => {
       assert.isOk(LocalBackend.counterEquals(metrics.spansFinished, 1));
     });
   });
+
+  it('should NOT mutate tags', () => {
+    const tags = {
+      robot: 'bender',
+    };
+    tracer = new Tracer('test-service-name', reporter, new ConstSampler(true), {
+      tags: tags,
+    });
+    tracer.close();
+    assert.notEqual(tags, tracer._tags);
+    assert.deepEqual(tags, {
+      robot: 'bender',
+    });
+  });
 });


### PR DESCRIPTION
Signed-off-by: Anton Fedorov <fapspirit@gmail.com>

## Which problem is this PR solving?

- Fixes mutation of tags provided by user (see #345 for more info)

## Short description of the changes

- Clone `options.tags` before assignment due to unnecessary mutations inside `Tracer`
