### PR TITLE
Wait statusCode 2xx for reset the batch spans

### DIFF
--- a/src/reporters/http_sender.js
+++ b/src/reporters/http_sender.js
@@ -111,7 +111,7 @@ export default class HTTPSender {
 
     const req = requester(this._httpOptions, resp => {
       
-      if(resp.statusCode && resp.statusCode === 200)
+      if(resp.statusCode && (resp.statusCode >= 200 || resp.statusCode < 227))
       {
         this._reset();  
       }

--- a/src/reporters/http_sender.js
+++ b/src/reporters/http_sender.js
@@ -107,11 +107,15 @@ export default class HTTPSender {
       return;
     }
 
-    this._reset();
-
     const requester = this._url.protocol === 'https:' ? https.request : http.request;
 
     const req = requester(this._httpOptions, resp => {
+      
+      if(resp.statusCode && resp.statusCode === 200)
+      {
+        this._reset();  
+      }
+      
       // consume response data to free up memory
       resp.resume();
       SenderUtils.invokeCallback(callback, numSpans);


### PR DESCRIPTION

## Which problem is this PR solving?

- when the http sender fail to send the span batches, spans are lose because they have been clear without waiting the statusCode of the request

## Short description of the changes

- Call reset only when we receive a 2xx status code
