### PR TITLE
Abort request on socket timeout

### DIFF
--- a/src/reporters/http_sender.js
+++ b/src/reporters/http_sender.js
@@ -122,6 +122,9 @@ export default class HTTPSender {
       this._logger.error(error);
       SenderUtils.invokeCallback(callback, numSpans, error);
     });
+    req.on('timeout', () => {
+      req.abort();
+    });
     req.write(result.value);
     req.end();
   }


### PR DESCRIPTION
Signed-off-by: Evan Simons <esimons@ebsco.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Resolves #353

## Short description of the changes

Manually abort request (closing socket) when timeout event is received. See: https://nodejs.org/api/http.html#http_event_timeout
> Emitted when the underlying socket times out from inactivity. This only notifies that the socket has been idle. **The request must be aborted manually.**

Tested this manually in a consuming service, however, and observing that the problematic behavior is resolved. Apologies there's no new unit test for this, wasn't sure quite how to implement a relevant test case; would be willing to implement with some guidance, but hoping this can be merged expeditiously if deemed valuable.

I don't believe this is a complete solution -- I think it's still creating a connection per span reported over HTTP -- but it at least handles the timeout event and closes the socket, rather than leaking.