### PR TITLE
Fix npm publish, rm unused dist/package.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ build-node: check-node-lts node-modules
 	node_modules/.bin/babel --presets env --plugins transform-class-properties --source-maps -d dist/crossdock/ crossdock/
 	cat src/version.js | sed "s|VERSION_TBD|$(shell node -p 'require("./package.json").version')|g" > dist/src/version.js
 	cp -R ./test/thrift ./dist/test/thrift/
-	cp package.json ./dist/
 	cp -R ./src/jaeger-idl ./dist/src/
 	rm -rf ./dist/src/jaeger-idl/.git
 	cp -R ./src/thriftrw-idl ./dist/src/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jaeger-client",
-  "version": "3.14.4",
+  "version": "3.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
## Which problem is this PR solving?

Publish omits the `dist/` folder.

## Short description of the changes

Remove unused `dist/package.json`, which was the cause of publish failing. The `dist/package.json` was being interpretted as the root of a different package, which caused npm to omit everything in `dist/` when publishing. Removing this file should resolve the publish issues. 

_Note: package.json was previously used to extract the current version of the node client, at runtime. That is now extracted from `dist/src/version.js` which is generated at build-time from `package.json#version`._
