### PR TITLE
Rename current samplers to LegacyV1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,15 @@ endif
 	npm run test-dist
 	npm run check-license
 
+.PHONY: test-without-install
+test-without-install: build-without-install
+	npm run flow
+ifeq ($(NODE_LTS),true)
+	npm run test-all
+endif
+	npm run test-dist
+	npm run check-license
+
 .PHONY: install-test-deps
 install-test-deps:
 ifeq ($(NODE_0_10), false)
@@ -44,7 +53,10 @@ check-node-lts:
 	@$(NODE_LTS) && echo Building using Node 10.x
 
 .PHONY: build-node
-build-node: check-node-lts node-modules
+build-node: check-node-lts node-modules build-without-install
+
+.PHONY: build-without-install
+build-without-install:
 	rm -rf ./dist/
 	node_modules/.bin/babel --presets env --plugins transform-class-properties --source-maps -d dist/src/ src/
 	node_modules/.bin/babel --presets env --plugins transform-class-properties --source-maps -d dist/test/ test/

--- a/src/_flow/legacy_sampler_v1.js
+++ b/src/_flow/legacy_sampler_v1.js
@@ -1,5 +1,5 @@
 // @flow
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at
@@ -11,7 +11,7 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-declare interface Sampler {
+declare interface LegacySamplerV1 {
   name(): string;
 
   /**
@@ -35,7 +35,7 @@ declare interface Sampler {
    */
   isSampled(operation: string, tags: any): boolean;
 
-  equal(other: Sampler): boolean;
+  equal(other: LegacySamplerV1): boolean;
 
   close(callback: ?Function): void;
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,8 +13,13 @@
 // SAMPLED_MASK is the bit mask indicating that a span has been sampled.
 export const SAMPLED_MASK = 0x1;
 
-// DEBUG_MASK is the bit mask indicationg that a span has been marked for debug.
+// DEBUG_MASK is the bit mask indicating that a span has been marked for debug.
 export const DEBUG_MASK = 0x2;
+
+// MASK = 0x4 is reserved for deferred sampling in the future.
+
+// FIREHOSE_MASK is the bit mask indicating a span is a firehose span.
+export const FIREHOSE_MASK = 0x8;
 
 // JAEGER_CLIENT_VERSION_TAG_KEY is the name of the tag used to report client version.
 export const JAEGER_CLIENT_VERSION_TAG_KEY = 'jaeger.version';

--- a/src/samplers/const_sampler.js
+++ b/src/samplers/const_sampler.js
@@ -13,7 +13,7 @@
 
 import * as constants from '../constants.js';
 
-export default class ConstSampler {
+export default class ConstSampler implements LegacySamplerV1 {
   _decision: boolean;
 
   constructor(decision: boolean) {
@@ -40,7 +40,7 @@ export default class ConstSampler {
     return this._decision;
   }
 
-  equal(other: Sampler): boolean {
+  equal(other: LegacySamplerV1): boolean {
     if (!(other instanceof ConstSampler)) {
       return false;
     }

--- a/src/samplers/guaranteed_throughput_sampler.js
+++ b/src/samplers/guaranteed_throughput_sampler.js
@@ -22,7 +22,7 @@ import RateLimitingSampler from './ratelimiting_sampler.js';
 //
 // The probabilisticSampler is given higher priority when tags are emitted, ie. if IsSampled() for both
 // samplers return true, the tags for probabilisticSampler will be used.
-export default class GuaranteedThroughputSampler {
+export default class GuaranteedThroughputSampler implements LegacySamplerV1 {
   _probabilisticSampler: ProbabilisticSampler;
   _lowerBoundSampler: RateLimitingSampler;
   _tagsPlaceholder: any;
@@ -59,7 +59,7 @@ export default class GuaranteedThroughputSampler {
     return decision;
   }
 
-  equal(other: Sampler): boolean {
+  equal(other: LegacySamplerV1): boolean {
     if (!(other instanceof GuaranteedThroughputSampler)) {
       return false;
     }

--- a/src/samplers/per_operation_sampler.js
+++ b/src/samplers/per_operation_sampler.js
@@ -23,7 +23,7 @@ type SamplersByOperation = { [key: string]: GuaranteedThroughputSampler, __proto
 // that all endpoints are represented in the sampled traces. If the number
 // of distinct operation names exceeds maxOperations, all other names are
 // sampled with a default probabilistic sampler.
-export default class PerOperationSampler {
+export default class PerOperationSampler implements LegacySamplerV1 {
   _maxOperations: number;
   _samplersByOperation: SamplersByOperation;
   _defaultSampler: ProbabilisticSampler;
@@ -78,7 +78,7 @@ export default class PerOperationSampler {
   }
 
   isSampled(operation: string, tags: any): boolean {
-    let sampler: Sampler = this._samplersByOperation[operation];
+    let sampler: LegacySamplerV1 = this._samplersByOperation[operation];
     if (!sampler) {
       if (Object.keys(this._samplersByOperation).length >= this._maxOperations) {
         return this._defaultSampler.isSampled(operation, tags);
@@ -89,7 +89,7 @@ export default class PerOperationSampler {
     return sampler.isSampled(operation, tags);
   }
 
-  equal(other: Sampler): boolean {
+  equal(other: LegacySamplerV1): boolean {
     return false; // TODO equal should be removed
   }
 

--- a/src/samplers/probabilistic_sampler.js
+++ b/src/samplers/probabilistic_sampler.js
@@ -13,7 +13,7 @@
 
 import * as constants from '../constants.js';
 
-export default class ProbabilisticSampler {
+export default class ProbabilisticSampler implements LegacySamplerV1 {
   _samplingRate: number;
 
   constructor(samplingRate: number) {
@@ -51,7 +51,7 @@ export default class ProbabilisticSampler {
     return Math.random();
   }
 
-  equal(other: Sampler): boolean {
+  equal(other: LegacySamplerV1): boolean {
     if (!(other instanceof ProbabilisticSampler)) {
       return false;
     }

--- a/src/samplers/ratelimiting_sampler.js
+++ b/src/samplers/ratelimiting_sampler.js
@@ -14,7 +14,7 @@
 import * as constants from '../constants.js';
 import RateLimiter from '../rate_limiter.js';
 
-export default class RateLimitingSampler {
+export default class RateLimitingSampler implements LegacySamplerV1 {
   _rateLimiter: RateLimiter;
   _maxTracesPerSecond: number;
 
@@ -63,7 +63,7 @@ export default class RateLimitingSampler {
     return decision;
   }
 
-  equal(other: Sampler): boolean {
+  equal(other: LegacySamplerV1): boolean {
     if (!(other instanceof RateLimitingSampler)) {
       return false;
     }

--- a/src/samplers/remote_sampler.js
+++ b/src/samplers/remote_sampler.js
@@ -28,9 +28,9 @@ const DEFAULT_SAMPLING_PORT = 5778;
 const PROBABILISTIC_STRATEGY_TYPE = 'PROBABILISTIC';
 const RATELIMITING_STRATEGY_TYPE = 'RATE_LIMITING';
 
-export default class RemoteControlledSampler {
+export default class RemoteControlledSampler implements LegacySamplerV1 {
   _serviceName: string;
-  _sampler: Sampler;
+  _sampler: LegacySamplerV1;
   _logger: Logger;
   _metrics: Metrics;
 
@@ -152,7 +152,7 @@ export default class RemoteControlledSampler {
       this._sampler = new PerOperationSampler(response.operationSampling, this._maxOperations);
       return true;
     }
-    let newSampler: Sampler;
+    let newSampler: LegacySamplerV1;
     if (response.strategyType === PROBABILISTIC_STRATEGY_TYPE && response.probabilisticSampling) {
       let samplingRate = response.probabilisticSampling.samplingRate;
       newSampler = new ProbabilisticSampler(samplingRate);
@@ -177,6 +177,10 @@ export default class RemoteControlledSampler {
 
   isSampled(operation: string, tags: any): boolean {
     return this._sampler.isSampled(operation, tags);
+  }
+
+  equal(other: LegacySamplerV1): boolean {
+    return false;
   }
 
   close(callback: ?Function): void {

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -34,7 +34,7 @@ import version from './version';
 export default class Tracer {
   _serviceName: string;
   _reporter: Reporter;
-  _sampler: Sampler;
+  _sampler: LegacySamplerV1;
   _logger: NullLogger;
   _tags: any;
   _injectors: any;
@@ -61,7 +61,7 @@ export default class Tracer {
   constructor(
     serviceName: string,
     reporter: Reporter = new NoopReporter(),
-    sampler: Sampler = new ConstSampler(false),
+    sampler: LegacySamplerV1 = new ConstSampler(false),
     options: any = {}
   ) {
     this._tags = options.tags ? Utils.clone(options.tags) : {};


### PR DESCRIPTION
Porting some of the changes from #372 to separate refactoring.

Part of #379 .