### PR TITLE
Run crossdock with all-in-one instead of Cassandra

### DIFF
--- a/crossdock/docker-compose.yml
+++ b/crossdock/docker-compose.yml
@@ -36,16 +36,22 @@ services:
         build:
             context: ../.
             dockerfile: crossdock/Dockerfile
+        links:
+            - "jaeger:jaeger-agent"
         ports:
             - "8080-8082"
 
     go:
         image: jaegertracing/xdock-go
+        links:
+            - "jaeger:jaeger-agent"
         ports:
             - "8080-8082"
 
     python:
         image: jaegertracing/xdock-py
+        links:
+            - "jaeger:jaeger-agent"
         ports:
             - "8080-8082"
 
@@ -54,14 +60,39 @@ services:
         ports:
             - "8080-8082"
         links:
-    #        Udp sender needs to know agent's address
-            - jaeger-agent
+            - "jaeger:jaeger-agent"
+        depends_on:
+            # Udp sender needs to know agent's address
+            - jaeger
 
     test_driver:
         image: jaegertracing/test-driver
         depends_on:
-            - jaeger-query
-            - jaeger-collector
-            - jaeger-agent
+            - jaeger
+        links:
+            - "jaeger:jaeger-agent"
+            - "jaeger:jaeger-collector"
+            - "jaeger:jaeger-query"
         ports:
             - "8080"
+        environment:
+            - JAEGER_QUERY_HC_HOST_PORT=jaeger-query:14269
+
+    jaeger:
+        image: jaegertracing/all-in-one
+        ports:
+            - "14269"
+            - "14268:14268"
+            - "14267"
+            - "14250"
+            - "9411:9411"
+            - "16686:16686"
+            - "16687"
+            - "5775:5775/udp"
+            - "6831:6831/udp"
+            - "6832:6832/udp"
+            - "5778:5778"
+        environment:
+            - COLLECTOR_ZIPKIN_HTTP_PORT=9411
+            - LOG_LEVEL=debug
+        restart: on-failure

--- a/crossdock/rules.mk
+++ b/crossdock/rules.mk
@@ -1,26 +1,24 @@
 PROJECT=crossdock
-JAEGER_COMPOSE_URL=https://raw.githubusercontent.com/jaegertracing/jaeger/master/docker-compose/jaeger-docker-compose.yml
-XDOCK_JAEGER_YAML=$(PROJECT)/jaeger-docker-compose.yml
 XDOCK_YAML=$(PROJECT)/docker-compose.yml
 
 .PHONY: crossdock
-crossdock: install_node_modules crossdock-download-jaeger
-	docker-compose -f $(XDOCK_YAML) -f $(XDOCK_JAEGER_YAML) kill node
-	docker-compose -f $(XDOCK_YAML) -f $(XDOCK_JAEGER_YAML) rm -f node
-	docker-compose -f $(XDOCK_YAML) -f $(XDOCK_JAEGER_YAML) build node
-	docker-compose -f $(XDOCK_YAML) -f $(XDOCK_JAEGER_YAML) run crossdock
+crossdock: install_node_modules
+	docker-compose -f $(XDOCK_YAML) kill node
+	docker-compose -f $(XDOCK_YAML) rm -f node
+	docker-compose -f $(XDOCK_YAML) build node
+	docker-compose -f $(XDOCK_YAML) run crossdock
 
 .PHONY: crossdock-fresh
-crossdock-fresh: install_node_modules crossdock-download-jaeger
-	docker-compose -f $(XDOCK_YAML) -f $(XDOCK_JAEGER_YAML) kill
-	docker-compose -f $(XDOCK_YAML) -f $(XDOCK_JAEGER_YAML) rm --force
-	docker-compose -f $(XDOCK_YAML) -f $(XDOCK_JAEGER_YAML) pull
-	docker-compose -f $(XDOCK_YAML) -f $(XDOCK_JAEGER_YAML) build --no-cache
-	docker-compose -f $(XDOCK_YAML) -f $(XDOCK_JAEGER_YAML) run crossdock
+crossdock-fresh: install_node_modules
+	docker-compose -f $(XDOCK_YAML) kill
+	docker-compose -f $(XDOCK_YAML) rm --force
+	docker-compose -f $(XDOCK_YAML) pull
+	docker-compose -f $(XDOCK_YAML) build --no-cache
+	docker-compose -f $(XDOCK_YAML) run crossdock
 
 .PHONY: crossdock-logs
-crossdock-logs: crossdock-download-jaeger
-	docker-compose -f $(XDOCK_YAML) -f $(XDOCK_JAEGER_YAML) logs
+crossdock-logs:
+	docker-compose -f $(XDOCK_YAML) logs
 
 .PHONY: install_node_modules
 install_node_modules:
@@ -35,7 +33,3 @@ install_docker_ci:
 	chmod +x docker-compose
 	sudo mv docker-compose /usr/local/bin
 	docker-compose version
-
-.PHONY: crossdock-download-jaeger
-crossdock-download-jaeger:
-	curl -o $(XDOCK_JAEGER_YAML) $(JAEGER_COMPOSE_URL)


### PR DESCRIPTION
Crossdock test often fails because we have to wait too long for Cassandra, while integration test hitting Cassandra is not relevant for the client tests.

This change borrows the awesome fix by @Falco20019 in https://github.com/jaegertracing/jaeger-client-csharp/pull/152 to use all-in-one for all Jaeger backend components, which makes the test run much faster and hopefully more reliably.