### PR TITLE
feat(propagator): inject value into carrier through set method of carrier if exists

### DIFF
--- a/src/propagators/text_map_codec.js
+++ b/src/propagators/text_map_codec.js
@@ -59,6 +59,14 @@ export default class TextMapCodec {
     }
   }
 
+  _set(carrier: any, key: string, value: string) {
+    if (carrier.set) {
+      carrier.set(key, value);
+    } else {
+      carrier[key] = value;
+    }
+  }
+
   extract(carrier: any): ?SpanContext {
     let spanContext = new SpanContext();
     let baggage = {};
@@ -92,13 +100,13 @@ export default class TextMapCodec {
 
   inject(spanContext: SpanContext, carrier: any): void {
     let stringSpanContext = spanContext.toString();
-    carrier[this._contextKey] = stringSpanContext; // no need to encode this
+    this._set(carrier, this._contextKey, stringSpanContext); // no need to encode this
 
     let baggage = spanContext.baggage;
     for (let key in baggage) {
       if (Object.prototype.hasOwnProperty.call(baggage, key)) {
         let value = this._encodeValue(spanContext.baggage[key]);
-        carrier[`${this._baggagePrefix}${key}`] = value;
+        this._set(carrier, `${this._baggagePrefix}${key}`, value);
       }
     }
   }

--- a/test/propagators.js
+++ b/test/propagators.js
@@ -53,6 +53,23 @@ describe('TextMapCodec', () => {
     let ctx = codec.extract(carrier);
     assert.deepEqual(ctx.baggage, { 'some-key': 'some-value' });
   });
+
+  it('should inject span context through carrier custon set method', () => {
+    let codec = new TextMapCodec({
+      urlEncoding: true,
+      contextKey: 'trace-context',
+      baggagePrefix: 'baggage-',
+    });
+    let carrier = {
+      value: {},
+      set(key, value) {
+        this.value[key] = value;
+      },
+    };
+    const spanContext = new SpanContext();
+    codec.inject(spanContext, carrier);
+    assert.equal(carrier.value['trace-context'], spanContext.toString());
+  });
 });
 
 describe('ZipkinB3TextMapCodec', () => {


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

- Carrier like [grpc metadata](https://github.com/grpc/grpc-node/blob/master/packages/grpc-native-core/index.d.ts#L529) can only be inserted value through its `set` or `update` methods. We should respect them.

## Short description of the changes

-  inject value into carrier through set method of carrier if exists
