### PR TITLE
Support configuring sampling url

### DIFF
--- a/src/samplers/remote_sampler.js
+++ b/src/samplers/remote_sampler.js
@@ -27,6 +27,7 @@ const DEFAULT_REFRESH_INTERVAL = 60000;
 const DEFAULT_MAX_OPERATIONS = 2000;
 const DEFAULT_SAMPLING_HOST = '0.0.0.0';
 const DEFAULT_SAMPLING_PORT = 5778;
+const DEFAULT_SAMPLING_PATH = '/sampling';
 const PROBABILISTIC_STRATEGY_TYPE = 'PROBABILISTIC';
 const RATE_LIMITING_STRATEGY_TYPE = 'RATE_LIMITING';
 
@@ -40,6 +41,7 @@ export default class RemoteControlledSampler implements Sampler {
   _refreshInterval: number;
   _host: string;
   _port: number;
+  _samplingPath: string;
   _maxOperations: number;
 
   _onSamplerUpdate: ?Function;
@@ -59,6 +61,7 @@ export default class RemoteControlledSampler implements Sampler {
    * @param {string} [options.hostPort] - host and port for jaeger-agent, defaults to 'localhost:5778'
    * @param {string} [options.host] - host for jaeger-agent, defaults to 'localhost'
    * @param {number} [options.port] - port for jaeger-agent for SamplingManager endpoint
+   * @param {string} [options.samplingPath] - path on jaeger-agent for SamplingManager endpoint
    * @param {number} [options.maxOperations] - max number of operations to track in PerOperationSampler
    * @param {function} [options.onSamplerUpdate]
    */
@@ -76,6 +79,9 @@ export default class RemoteControlledSampler implements Sampler {
     } else {
       this._host = options.host || DEFAULT_SAMPLING_HOST;
       this._port = options.port || DEFAULT_SAMPLING_PORT;
+    }
+    if (options.samplingPath) {
+      this._samplingPath = options.samplingPath|| DEFAULT_SAMPLING_PATH;
     }
     this._onSamplerUpdate = options.onSamplerUpdate;
 
@@ -118,7 +124,7 @@ export default class RemoteControlledSampler implements Sampler {
       this._logger.error(`Error in fetching sampling strategy: ${err}.`);
       this._metrics.samplerQueryFailure.increment(1);
     };
-    Utils.httpGet(this._host, this._port, `/sampling?service=${serviceName}`, success, error);
+    Utils.httpGet(this._host, this._port, `${this._samplingPath}?service=${serviceName}`, success, error);
   }
 
   _handleSamplingServerResponse(body: string) {

--- a/src/samplers/remote_sampler.js
+++ b/src/samplers/remote_sampler.js
@@ -80,9 +80,7 @@ export default class RemoteControlledSampler implements Sampler {
       this._host = options.host || DEFAULT_SAMPLING_HOST;
       this._port = options.port || DEFAULT_SAMPLING_PORT;
     }
-    if (options.samplingPath) {
-      this._samplingPath = options.samplingPath|| DEFAULT_SAMPLING_PATH;
-    }
+    this._samplingPath = options.samplingPath || DEFAULT_SAMPLING_PATH;
     this._onSamplerUpdate = options.onSamplerUpdate;
 
     if (options.refreshInterval !== 0) {

--- a/test/samplers/remote_sampler.js
+++ b/test/samplers/remote_sampler.js
@@ -255,4 +255,13 @@ describe('RemoteSampler', () => {
     assert.deepEqual(decision, remoteSampler.onSetTag(span, 'pi', 3.1415));
     assert.deepEqual([span, 'pi', 3.1415], mockSampler._onSetTag);
   });
+
+  it ('should support setting a custom path for sampling endpoint', done => {
+    let samplingPath = '/custom-sampling-path';
+    let remoteSampler = new RemoteSampler('service1', {
+      samplingPath: samplingPath
+    });
+    assert.equal(remoteSampler._samplingPath, samplingPath);
+    remoteSampler.close();
+  });
 });

--- a/test/samplers/remote_sampler.js
+++ b/test/samplers/remote_sampler.js
@@ -256,12 +256,11 @@ describe('RemoteSampler', () => {
     assert.deepEqual([span, 'pi', 3.1415], mockSampler._onSetTag);
   });
 
-  it ('should support setting a custom path for sampling endpoint', done => {
+  it('should support setting a custom path for sampling endpoint', () => {
     let samplingPath = '/custom-sampling-path';
-    let remoteSampler = new RemoteSampler('service1', {
-      samplingPath: samplingPath
+    let rs = new RemoteSampler('service1', {
+      samplingPath: samplingPath,
     });
-    assert.equal(remoteSampler._samplingPath, samplingPath);
-    remoteSampler.close();
+    assert.equal(rs._samplingPath, samplingPath);
   });
 });


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

- Allows users to specify a custom sampling endpoint on the agent so that they may experiment easily.

## Short description of the changes

- Add a configuration that takes in sampling path, defaulting to `/sampling`
