### PR TITLE
Initialize SpanContext.parentId to `null`

### DIFF
--- a/src/span_context.js
+++ b/src/span_context.js
@@ -41,7 +41,7 @@ export default class SpanContext {
   ) {
     this._traceId = traceId;
     this._spanId = spanId;
-    this._parentId = parentId;
+    this._parentId = parentId || null;
     this._traceIdStr = traceIdStr;
     this._spanIdStr = spanIdStr;
     this._parentIdStr = parentIdStr;

--- a/test/span_context.js
+++ b/test/span_context.js
@@ -22,6 +22,11 @@ describe('SpanContext', () => {
     LARGEST_64_BUFFER.writeUInt32BE(0xffffffff, 4);
   });
 
+  it('should initialize parent to null', () => {
+    let ctx = SpanContext.constructor();
+    assert.equal(null, ctx.parentId);
+  });
+
   it('should return given values as they were set', () => {
     let traceId = Utils.encodeInt64(1);
     let spanId = Utils.encodeInt64(2);

--- a/test/tracer.js
+++ b/test/tracer.js
@@ -163,7 +163,7 @@ describe('tracer should', () => {
     });
 
     assert.equal(span.context().traceId, span.context().spanId);
-    assert.isNotOk(span.context().parentId);
+    assert.equal(span.context().parentId, null);
     assert.isOk(span.context().isSampled());
     assert.equal(span._startTime, startTime);
   });


### PR DESCRIPTION
Resolves #386

Signed-off-by: Prithvi Raj <p.r@uber.com>

