### PR TITLE
Export experimental samplers via index

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,8 @@ import ConstSampler from './samplers/const_sampler';
 import ProbabilisticSampler from './samplers/probabilistic_sampler';
 import RateLimitingSampler from './samplers/rate_limiting_sampler';
 import RemoteSampler from './samplers/remote_sampler';
+import PrioritySampler from './samplers/experimental/priority_sampler';
+import TagEqualsSampler from './samplers/experimental/tag_equals_sampler';
 
 import CompositeReporter from './reporters/composite_reporter';
 import InMemoryReporter from './reporters/in_memory_reporter';
@@ -50,6 +52,10 @@ module.exports = {
   ProbabilisticSampler,
   RateLimitingSampler,
   RemoteSampler,
+  experimental: {
+    PrioritySampler,
+    TagEqualsSampler,
+  },
 
   CompositeReporter,
   InMemoryReporter,

--- a/test/samplers/exp_priority_sampler.js
+++ b/test/samplers/exp_priority_sampler.js
@@ -14,14 +14,13 @@
 import { assert } from 'chai';
 import sinon from 'sinon';
 import * as opentracing from 'opentracing';
-import Span from '../../src/span';
+import { ConstSampler, InMemoryReporter, Span, Tracer } from '../../src/index';
 import Utils from '../../src/util';
-import ConstSampler from '../../src/samplers/const_sampler';
-import TagEqualsSampler from '../../src/samplers/experimental/tag_equals_sampler';
-import PrioritySampler from '../../src/samplers/experimental/priority_sampler';
-import InMemoryReporter from '../../src/reporters/in_memory_reporter';
-import Tracer from '../../src/tracer';
 import BaseSamplerV2 from '../../src/samplers/v2/base';
+
+// import these from index to test 'experimental' export.
+var PrioritySampler = require('../../src/index').experimental.PrioritySampler;
+var TagEqualsSampler = require('../../src/index').experimental.TagEqualsSampler;
 
 describe('PrioritySampler with TagSampler', () => {
   const tagSampler = new TagEqualsSampler('theWho', [

--- a/test/samplers/exp_tag_sampler.js
+++ b/test/samplers/exp_tag_sampler.js
@@ -14,11 +14,10 @@
 import { assert } from 'chai';
 import sinon from 'sinon';
 import * as opentracing from 'opentracing';
-import Span from '../../src/span';
+import { Span, Tracer, InMemoryReporter } from '../../src/index';
 import Utils from '../../src/util';
-import TagEqualsSampler from '../../src/samplers/experimental/tag_equals_sampler';
-import InMemoryReporter from '../../src/reporters/in_memory_reporter';
-import Tracer from '../../src/tracer';
+
+var TagEqualsSampler = require('../../src/index').experimental.TagEqualsSampler;
 
 describe('TagSampler', () => {
   const tagSampler = new TagEqualsSampler('theWho', [


### PR DESCRIPTION
test should be using import from index whenever possible for types that are supposed to be public