### PR TITLE
Use more precise tests than isNotOk

### DIFF
--- a/test/http_sender.js
+++ b/test/http_sender.js
@@ -158,7 +158,7 @@ describe('http sender', () => {
         const tSpan = ThriftUtils.spanToThrift(span);
 
         server.on('batchReceived', function(batch) {
-          assert.isOk(batch);
+          assert.isNotNull(batch);
           assertThriftSpanEqual(assert, tSpan, batch.spans[0]);
 
           if (o.expectedTraceId) {
@@ -168,7 +168,7 @@ describe('http sender', () => {
           if (o.expectedParentId) {
             assert.deepEqual(batch.spans[0].parentId, o.expectedParentId);
           } else {
-            assert.isNotOk(batch.spans[0].parentId);
+            assert.isUndefined(batch.spans[0].parentId);
           }
 
           done();

--- a/test/propagators.js
+++ b/test/propagators.js
@@ -89,11 +89,11 @@ describe('ZipkinB3TextMapCodec', () => {
     };
 
     let ctx = codec.extract(carrier);
-    assert.isNotOk(ctx.parentIdStr);
-    assert.isNotOk(ctx.spanIdStr);
-    assert.isNotOk(ctx.traceIdStr);
-    assert.equal(ctx.isSampled(), true);
-    assert.equal(ctx.isDebug(), true);
+    assert.equal('', ctx.parentIdStr);
+    assert.equal('', ctx.spanIdStr);
+    assert.equal('', ctx.traceIdStr);
+    assert.isTrue(ctx.isSampled());
+    assert.isTrue(ctx.isDebug());
   });
   it('should not extract parentspanid if not injected', () => {
     let codec = new ZipkinB3TextMapCodec({ urlEncoding: true });

--- a/test/samplers/all_samplers.js
+++ b/test/samplers/all_samplers.js
@@ -122,7 +122,7 @@ describe('ConstSampler', () => {
 
   it('does NOT equal another type of sampler', () => {
     let otherSampler = new ProbabilisticSampler(0.5);
-    assert.isNotOk(sampler.equal(otherSampler));
+    assert.isFalse(sampler.equal(otherSampler));
   });
 
   it('does equal the same type of sampler', () => {
@@ -141,13 +141,13 @@ describe('ProbabilisticSampler', () => {
   it('calls is Sampled, and returns false', () => {
     let sampler = new ProbabilisticSampler(0.0);
     let tags = {};
-    assert.isNotOk(sampler.isSampled('operation', tags));
+    assert.isFalse(sampler.isSampled('operation', tags));
     assert.deepEqual(tags, {});
   });
 
   it('does NOT equal another type of sampler', () => {
     let sampler = new ProbabilisticSampler(0.0);
     let otherSampler = new ConstSampler(true);
-    assert.isNotOk(sampler.equal(otherSampler));
+    assert.isFalse(sampler.equal(otherSampler));
   });
 });

--- a/test/samplers/guaranteed_throughput_sampler.js
+++ b/test/samplers/guaranteed_throughput_sampler.js
@@ -109,8 +109,8 @@ describe('GuaranteedThroughput sampler', () => {
     let p2 = sampler._lowerBoundSampler;
     let isUpdated: boolean = sampler.update(2, 0.9);
     assert.isTrue(isUpdated);
-    assert.isFalse(p1 === sampler._probabilisticSampler);
-    assert.strictEqual(sampler._lowerBoundSampler, p2);
+    assert.notStrictEqual(p1, sampler._probabilisticSampler);
+    assert.strictEqual(p2, sampler._lowerBoundSampler);
     assertValues(sampler, 2, 0.9);
   });
 

--- a/test/samplers/guaranteed_throughput_sampler.js
+++ b/test/samplers/guaranteed_throughput_sampler.js
@@ -56,7 +56,7 @@ describe('GuaranteedThroughput sampler', () => {
         assert.isOk(decision, 'must sample');
         assert.deepEqual(expectedTags, actualTags);
       } else {
-        assert.isNotOk(decision, 'must not sample');
+        assert.isFalse(decision, 'must not sample');
         assert.deepEqual({}, actualTags);
       }
     });
@@ -109,7 +109,7 @@ describe('GuaranteedThroughput sampler', () => {
     let p2 = sampler._lowerBoundSampler;
     let isUpdated: boolean = sampler.update(2, 0.9);
     assert.isTrue(isUpdated);
-    assert.isNotOk(p1 === sampler._probabilisticSampler);
+    assert.isFalse(p1 === sampler._probabilisticSampler);
     assert.strictEqual(sampler._lowerBoundSampler, p2);
     assertValues(sampler, 2, 0.9);
   });
@@ -151,7 +151,7 @@ describe('GuaranteedThroughput sampler', () => {
         assert.isOk(decision, `must sample, test case ${testCase.num}`);
         assert.deepEqual(expectedTags, actualTags, `must match tags, test case ${testCase.num}`);
       } else {
-        assert.isNotOk(decision, `must not sample, test case ${testCase.num}`);
+        assert.isFalse(decision, `must not sample, test case ${testCase.num}`);
         assert.deepEqual({}, actualTags, `must not have tags, test case ${testCase.num}`);
       }
     });

--- a/test/samplers/rate_limiting_sampler.js
+++ b/test/samplers/rate_limiting_sampler.js
@@ -26,7 +26,7 @@ describe('RateLimitingSampler should', () => {
     }
 
     assert.equal(sampler.maxTracesPerSecond, 10);
-    assert.isNotOk(sampler.equal(new ProbabilisticSampler(0.5)));
+    assert.isFalse(sampler.equal(new ProbabilisticSampler(0.5)));
 
     let tags = {};
     let decision = sampler.isSampled('operation', tags);

--- a/test/span_context.js
+++ b/test/span_context.js
@@ -52,8 +52,8 @@ describe('SpanContext', () => {
     assert.isOk(context.isDebug());
 
     context.flags = 0;
-    assert.isNotOk(context.isSampled());
-    assert.isNotOk(context.isDebug());
+    assert.isFalse(context.isSampled());
+    assert.isFalse(context.isDebug());
   });
 
   it('should format strings properly with toString', () => {

--- a/test/tchannel_bridge.js
+++ b/test/tchannel_bridge.js
@@ -104,7 +104,7 @@ describe('test tchannel span bridge', () => {
         let tracedChannel = bridge.tracedChannel(encodedChannel);
 
         let clientCallback = (err, res, headers, body) => {
-          assert.isNotOk(err);
+          assert.isNull(err);
           assert.equal(reporter.spans.length, 2);
 
           // the first span to be reported is the server span

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -41,8 +41,8 @@ describe('TestUtils', () => {
     span.addTags(tags);
 
     assert.isOk(TestUtils.hasTags(span, tags));
-    assert.isNotOk(TestUtils.hasTags(span, { k: 'v' }));
-    assert.isNotOk(TestUtils.hasTags(span, { keyOne: 'valueTwo' }));
+    assert.isFalse(TestUtils.hasTags(span, { k: 'v' }));
+    assert.isFalse(TestUtils.hasTags(span, { keyOne: 'valueTwo' }));
   });
 
   it('should support getTags', () => {

--- a/test/text_map_codec.js
+++ b/test/text_map_codec.js
@@ -51,10 +51,10 @@ describe('Text Map Codec should', () => {
 
     let span = tracer.startSpan('root', { childOf: context });
 
-    assert.isNotOk(span.context().parentId);
-    assert.isOk(span.context().traceId !== 0);
-    assert.isOk(span.context().isSampled());
-    assert.isOk(span.context().isDebug());
+    assert.isNull(span.context().parentId);
+    assert.notEqual('', span.context().traceIdStr);
+    assert.isTrue(span.context().isSampled());
+    assert.isTrue(span.context().isDebug());
 
     let tagFound = false;
     for (let i = 0; i < span._tags.length; i++) {
@@ -82,7 +82,7 @@ describe('Text Map Codec should', () => {
 
     let span = tracer.startSpan('root', { childOf: context });
     let prevTagLength = span._tags.length;
-    assert.isNotOk(span.context().isDebug());
+    assert.isFalse(span.context().isDebug());
     assert.equal(
       prevTagLength,
       span._tags.length,

--- a/test/throttler/default_throttler.js
+++ b/test/throttler/default_throttler.js
@@ -17,7 +17,7 @@ describe('DefaultThrottler should', () => {
   it('throttle everything', () => {
     const throttler = new DefaultThrottler(true);
     throttler.setProcess({});
-    assert.isNotOk(throttler.isAllowed('key'));
+    assert.isFalse(throttler.isAllowed('key'));
     throttler.close();
   });
 

--- a/test/throttler/remote_throttler.js
+++ b/test/throttler/remote_throttler.js
@@ -66,7 +66,7 @@ describe('RemoteThrottler should', () => {
       assert.equal(LocalBackend.counterValue(metrics.throttledDebugSpans), 1);
       done();
     };
-    assert.isNotOk(throttler.isAllowed(operation));
+    assert.isFalse(throttler.isAllowed(operation));
     throttler._refreshCredits();
   });
 
@@ -86,18 +86,18 @@ describe('RemoteThrottler should', () => {
   });
 
   it("return false for _isAllowed if operation isn't in _credits or operation has no credits", () => {
-    assert.isNotOk(
+    assert.isFalse(
       throttler._isAllowed(operation),
       'operation is not set so operation should not be allowed'
     );
     throttler._credits[operation] = 0;
-    assert.isNotOk(throttler._isAllowed(operation), 'operation is set but lacks credit');
+    assert.isFalse(throttler._isAllowed(operation), 'operation is set but lacks credit');
     assert.equal(LocalBackend.counterValue(metrics.throttledDebugSpans), 2);
   });
 
   it("return false for isAllowed if operation doesn't have enough credits", () => {
     throttler._credits[operation] = 0.5;
-    assert.isNotOk(throttler._isAllowed(operation));
+    assert.isFalse(throttler._isAllowed(operation));
     assert.equal(LocalBackend.counterValue(metrics.throttledDebugSpans), 1);
   });
 

--- a/test/tracer.js
+++ b/test/tracer.js
@@ -91,7 +91,7 @@ describe('tracer should', () => {
     let rootSpan = tracer.startSpan('fry', { childOf: spanContext });
 
     assert.isOk(rootSpan.context().traceId);
-    assert.isNotOk(rootSpan.context().parentId);
+    assert.isNull(rootSpan.context().parentId);
     assert.equal(rootSpan.context().flags, 1);
     assert.equal('Bender', rootSpan.getBaggageItem('robot'));
     assert.equal('Leela', rootSpan.getBaggageItem('female'));

--- a/test/udp_sender.js
+++ b/test/udp_sender.js
@@ -152,7 +152,7 @@ describe('udp sender', () => {
           if (o.expectedParentId) {
             assert.deepEqual(batch.spans[0].parentId, o.expectedParentId);
           } else {
-            assert.isNotOk(batch.spans[0].parentId);
+            assert.isUndefined(batch.spans[0].parentId);
           }
 
           sender.close();

--- a/test/zipkin_b3_text_map_codec.js
+++ b/test/zipkin_b3_text_map_codec.js
@@ -86,9 +86,9 @@ describe('Zipkin B3 Text Map Codec should', () => {
       let context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, testCase);
 
       assert.isOk(context);
-      assert.isNotOk(context.spanIdStr);
-      assert.isNotOk(context.traceIdStr);
-      assert.isNotOk(context.parentIdStr);
+      assert.equal('', context.spanIdStr);
+      assert.equal('', context.traceIdStr);
+      assert.equal('', context.parentIdStr);
     });
   });
 
@@ -123,7 +123,7 @@ describe('Zipkin B3 Text Map Codec should', () => {
 
     let context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
     assert.isOk(context.isSampled());
-    assert.isNotOk(context.isDebug());
+    assert.isFalse(context.isDebug());
   });
 
   it('not set the sampled flag if sampling is denied', () => {
@@ -132,7 +132,7 @@ describe('Zipkin B3 Text Map Codec should', () => {
     };
 
     const context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
-    assert.isNotOk(context.isSampled());
+    assert.isFalse(context.isSampled());
   });
 
   it('handle true value for the sampled header', () => {
@@ -150,7 +150,7 @@ describe('Zipkin B3 Text Map Codec should', () => {
     };
 
     let context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
-    assert.isNotOk(context.isSampled());
+    assert.isFalse(context.isSampled());
   });
 
   it('set the debug and sampled flags when the zipkin flags header is received', () => {
@@ -167,8 +167,8 @@ describe('Zipkin B3 Text Map Codec should', () => {
     };
 
     context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
-    assert.isNotOk(context.isSampled());
-    assert.isNotOk(context.isDebug());
+    assert.isFalse(context.isSampled());
+    assert.isFalse(context.isDebug());
   });
 
   it('should set the sampled header to "0" if not sampling', () => {


### PR DESCRIPTION
`assert.isNotOk` can match too many conditions, sometimes giving false positives in the tests.

Change to use more precise asserts, like isFalse when checking boolean fields.