### PR TITLE
Use more precise tests than isOk

### DIFF
--- a/src/span.js
+++ b/src/span.js
@@ -56,10 +56,6 @@ export default class Span {
     return this._tracer._serviceName;
   }
 
-  getTags(): Array<Tag> {
-    return this._tags;
-  }
-
   static _getBaggageHeaderCache() {
     if (!Span._baggageHeaderCache) {
       Span._baggageHeaderCache = {};

--- a/test/all_reporters.js
+++ b/test/all_reporters.js
@@ -69,7 +69,7 @@ describe('All Reporters should', () => {
 
       reporter.close(o.callback);
 
-      assert.isOk(o.predicate(o.callback));
+      assert.isTrue(o.predicate(o.callback));
     });
   });
 
@@ -101,7 +101,7 @@ describe('All Reporters should', () => {
       let reporter = new CompositeReporter([mockReporter]);
       reporter.report();
 
-      assert.isOk(mockReporter.report.calledOnce);
+      assert.isTrue(mockReporter.report.calledOnce);
     });
   });
 });

--- a/test/http_sender.js
+++ b/test/http_sender.js
@@ -105,7 +105,6 @@ describe('http sender', () => {
     spanTwo = ThriftUtils.spanToThrift(spanTwo);
 
     server.on('batchReceived', batch => {
-      assert.isOk(batch);
       assert.equal(batch.spans.length, 2);
 
       assertThriftSpanEqual(assert, spanOne, batch.spans[0]);

--- a/test/remote_reporter.js
+++ b/test/remote_reporter.js
@@ -61,7 +61,7 @@ describe('Remote Reporter', () => {
 
     reporter.flush(() => {
       assert.equal(sender._batch.spans.length, 0);
-      assert.isOk(LocalBackend.counterEquals(metrics.reporterSuccess, 1));
+      assert.isTrue(LocalBackend.counterEquals(metrics.reporterSuccess, 1));
       done();
     });
   });
@@ -96,7 +96,7 @@ describe('Remote Reporter', () => {
     reporter._sender = mockSender;
     reporter.flush(() => {
       expect(logger._errorMsgs[0]).to.have.string('Failed to flush spans in reporter');
-      assert.isOk(LocalBackend.counterEquals(metrics.reporterFailure, 1));
+      assert.isTrue(LocalBackend.counterEquals(metrics.reporterFailure, 1));
       done();
     });
   });

--- a/test/samplers/all_samplers.js
+++ b/test/samplers/all_samplers.js
@@ -117,7 +117,7 @@ describe('ConstSampler', () => {
   });
 
   it('decision reflects given parameter', () => {
-    assert.isOk(sampler.decision);
+    assert.isTrue(sampler.decision);
   });
 
   it('does NOT equal another type of sampler', () => {
@@ -127,7 +127,7 @@ describe('ConstSampler', () => {
 
   it('does equal the same type of sampler', () => {
     let otherSampler = new ConstSampler(true);
-    assert.isOk(sampler.equal(otherSampler));
+    assert.isTrue(sampler.equal(otherSampler));
   });
 });
 

--- a/test/samplers/exp_priority_sampler.js
+++ b/test/samplers/exp_priority_sampler.js
@@ -73,7 +73,7 @@ describe('PrioritySampler with TagSampler', () => {
     let span = tracer.startSpan('opName');
     let carrier = {};
     tracer.inject(span.context(), opentracing.FORMAT_TEXT_MAP, carrier);
-    assert.isOk(carrier);
+    assert.isDefined(carrier['uber-trace-id']);
     assert.isFalse(span._spanContext.isSampled(), 'sampled');
     assert.isFalse(span._spanContext.samplingFinalized, 'finalized');
   });

--- a/test/samplers/exp_tag_sampler.js
+++ b/test/samplers/exp_tag_sampler.js
@@ -38,8 +38,6 @@ describe('TagSampler', () => {
 
   it('should sample and finalize created span with tag', () => {
     let span = tracer.startSpan('opName', { tags: { theWho: 'Bender' } });
-    console.log('span has tags');
-    console.log(span.getTags());
     assert.isTrue(span._spanContext.isSampled(), 'sampled');
     assert.isTrue(span._spanContext.samplingFinalized, 'finalized');
   });

--- a/test/samplers/guaranteed_throughput_sampler.js
+++ b/test/samplers/guaranteed_throughput_sampler.js
@@ -53,7 +53,7 @@ describe('GuaranteedThroughput sampler', () => {
       // Since the test runs under one second, we expect 2 successful samples
       // and one unsuccessful.
       if (expectedDecision) {
-        assert.isOk(decision, 'must sample');
+        assert.isTrue(decision, 'must sample');
         assert.deepEqual(expectedTags, actualTags);
       } else {
         assert.isFalse(decision, 'must not sample');
@@ -148,7 +148,7 @@ describe('GuaranteedThroughput sampler', () => {
       let actualTags = {};
       let decision = sampler.isSampled('testOperationName', actualTags);
       if (expectedDecision) {
-        assert.isOk(decision, `must sample, test case ${testCase.num}`);
+        assert.isTrue(decision, `must sample, test case ${testCase.num}`);
         assert.deepEqual(expectedTags, actualTags, `must match tags, test case ${testCase.num}`);
       } else {
         assert.isFalse(decision, `must not sample, test case ${testCase.num}`);

--- a/test/samplers/rate_limiting_sampler.js
+++ b/test/samplers/rate_limiting_sampler.js
@@ -51,7 +51,7 @@ describe('RateLimitingSampler should', () => {
     let sampler = new RateLimitingSampler(1.0);
     let otherSampler = new RateLimitingSampler(1.0);
 
-    assert.isOk(sampler.equal(otherSampler));
+    assert.isTrue(sampler.equal(otherSampler));
   });
 
   it('work with maxCreditsPerSecond smaller than 1', () => {

--- a/test/samplers/remote_sampler.js
+++ b/test/samplers/remote_sampler.js
@@ -117,7 +117,7 @@ describe('RemoteSampler', () => {
   it('should set ratelimiting sampler', done => {
     let maxTracesPerSecond = 10;
     remoteSampler._onSamplerUpdate = s => {
-      assert.isOk(s.equal(new RateLimitingSampler(maxTracesPerSecond)));
+      assert.isTrue(s.equal(new RateLimitingSampler(maxTracesPerSecond)));
       done();
     };
     server.addStrategy('service1', {
@@ -135,7 +135,7 @@ describe('RemoteSampler', () => {
     let maxTracesPerSecond = 5;
     remoteSampler._onSamplerUpdate = s => {
       assert.strictEqual(rateLimitingSampler, remoteSampler._sampler);
-      assert.isOk(s.equal(new RateLimitingSampler(maxTracesPerSecond)));
+      assert.isTrue(s.equal(new RateLimitingSampler(maxTracesPerSecond)));
       done();
     };
     server.addStrategy('service1', {
@@ -176,7 +176,7 @@ describe('RemoteSampler', () => {
       },
     });
     remoteSampler._onSamplerUpdate = s => {
-      assert.isOk(s instanceof PerOperationSampler);
+      assert.isTrue(s instanceof PerOperationSampler);
       assert.equal(LocalBackend.counterValue(metrics.samplerRetrieved), 1);
       assert.equal(LocalBackend.counterValue(metrics.samplerUpdated), 1);
 

--- a/test/span.js
+++ b/test/span.js
@@ -391,7 +391,6 @@ describe('sampling finalizer', () => {
     let carrier = {};
     tracer.inject(span2.context(), opentracing.FORMAT_HTTP_HEADERS, carrier);
     let ctx = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, carrier);
-    console.log(ctx);
     assert.isTrue(ctx.isRemote(), 'extracted context is "remote"');
     let span3 = tracer.startSpan('test2', { childOf: ctx });
     assert.isTrue(span3.context().samplingFinalized, 'child span of remote parent is finalized');

--- a/test/span_context.js
+++ b/test/span_context.js
@@ -48,8 +48,8 @@ describe('SpanContext', () => {
       Utils.encodeInt64(3),
       3
     );
-    assert.isOk(context.isSampled());
-    assert.isOk(context.isDebug());
+    assert.isTrue(context.isSampled());
+    assert.isTrue(context.isDebug());
 
     context.flags = 0;
     assert.isFalse(context.isSampled());

--- a/test/tchannel_bridge.js
+++ b/test/tchannel_bridge.js
@@ -122,8 +122,8 @@ describe('test tchannel span bridge', () => {
           clientSpanTags[opentracing.Tags.PEER_SERVICE] = 'server';
           clientSpanTags[opentracing.Tags.SPAN_KIND] = opentracing.Tags.SPAN_KIND_RPC_CLIENT;
 
-          assert.isOk(TestUtils.hasTags(serverSpan, serverSpanTags));
-          assert.isOk(TestUtils.hasTags(clientSpan, clientSpanTags));
+          assert.isTrue(TestUtils.hasTags(serverSpan, serverSpanTags));
+          assert.isTrue(TestUtils.hasTags(clientSpan, clientSpanTags));
           assert.equal(serverSpan.context().parentIdStr, clientSpan.context().spanIdStr);
           // If context exists then the following conditions are true
           // else the following conditons are false

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -40,7 +40,7 @@ describe('TestUtils', () => {
     };
     span.addTags(tags);
 
-    assert.isOk(TestUtils.hasTags(span, tags));
+    assert.isTrue(TestUtils.hasTags(span, tags));
     assert.isFalse(TestUtils.hasTags(span, { k: 'v' }));
     assert.isFalse(TestUtils.hasTags(span, { keyOne: 'valueTwo' }));
   });

--- a/test/text_map_codec.js
+++ b/test/text_map_codec.js
@@ -51,10 +51,10 @@ describe('Text Map Codec should', () => {
 
     let span = tracer.startSpan('root', { childOf: context });
 
-    assert.isNull(span.context().parentId);
-    assert.notEqual('', span.context().traceIdStr);
-    assert.isTrue(span.context().isSampled());
-    assert.isTrue(span.context().isDebug());
+    assert.isNotOk(span.context().parentId);
+    assert.isOk(span.context().traceId !== 0);
+    assert.isOk(span.context().isSampled());
+    assert.isOk(span.context().isDebug());
 
     let tagFound = false;
     for (let i = 0; i < span._tags.length; i++) {
@@ -82,7 +82,7 @@ describe('Text Map Codec should', () => {
 
     let span = tracer.startSpan('root', { childOf: context });
     let prevTagLength = span._tags.length;
-    assert.isFalse(span.context().isDebug());
+    assert.isNotOk(span.context().isDebug());
     assert.equal(
       prevTagLength,
       span._tags.length,

--- a/test/throttler/default_throttler.js
+++ b/test/throttler/default_throttler.js
@@ -24,7 +24,7 @@ describe('DefaultThrottler should', () => {
   it('throttle nothing', done => {
     const throttler = new DefaultThrottler();
     throttler.setProcess({});
-    assert.isOk(throttler.isAllowed('key'));
+    assert.isTrue(throttler.isAllowed('key'));
     throttler.close(done);
   });
 });

--- a/test/throttler/remote_throttler.js
+++ b/test/throttler/remote_throttler.js
@@ -60,7 +60,7 @@ describe('RemoteThrottler should', () => {
     throttler.setProcess({ uuid: uuid });
     server.addCredits(serviceName, [{ operation: operation, balance: 3 }]);
     creditsUpdatedHook = _throttler => {
-      assert.isOk(_throttler.isAllowed(operation));
+      assert.isTrue(_throttler.isAllowed(operation));
       assert.equal(_throttler._credits[operation], 2);
       assert.equal(LocalBackend.counterValue(metrics.throttlerUpdateSuccess), 1);
       assert.equal(LocalBackend.counterValue(metrics.throttledDebugSpans), 1);
@@ -110,9 +110,9 @@ describe('RemoteThrottler should', () => {
     throttler._credits[operation] = 0;
     throttler._credits[other_operation] = 0;
     creditsUpdatedHook = _throttler => {
-      assert.isOk(_throttler.isAllowed(operation));
+      assert.isTrue(_throttler.isAllowed(operation));
       assert.equal(_throttler._credits[operation], 4);
-      assert.isOk(_throttler.isAllowed(other_operation));
+      assert.isTrue(_throttler.isAllowed(other_operation));
       assert.equal(_throttler._credits[other_operation], 2);
       assert.equal(LocalBackend.counterValue(metrics.throttlerUpdateSuccess), 1);
       done();
@@ -166,7 +166,7 @@ describe('RemoteThrottler should', () => {
     throttler._credits[operation] = 0;
     server.addCredits(serviceName, [{ operation: operation, balance: 5 }]);
     creditsUpdatedHook = _throttler => {
-      assert.isOk(_throttler.isAllowed(operation));
+      assert.isTrue(_throttler.isAllowed(operation));
       assert.equal(_throttler._credits[operation], 4);
       assert.equal(LocalBackend.counterValue(metrics.throttlerUpdateSuccess), 1);
       done();

--- a/test/tracer.js
+++ b/test/tracer.js
@@ -90,7 +90,8 @@ describe('tracer should', () => {
     let spanContext = tracer.extract(opentracing.FORMAT_TEXT_MAP, headers);
     let rootSpan = tracer.startSpan('fry', { childOf: spanContext });
 
-    assert.isOk(rootSpan.context().traceId);
+    assert.isNotNull(rootSpan.context().traceId);
+    assert.isDefined(rootSpan.context().traceId);
     assert.isNull(rootSpan.context().parentId);
     assert.equal(rootSpan.context().flags, 1);
     assert.equal('Bender', rootSpan.getBaggageItem('robot'));
@@ -130,7 +131,7 @@ describe('tracer should', () => {
     assert.deepEqual(span.context().parentId, parentId);
     assert.equal(span.context().flags, flags);
     assert.equal(span._startTime, start);
-    assert.isOk(
+    assert.isTrue(
       JaegerTestUtils.hasTags(span, {
         keyOne: 'Leela',
         keyTwo: 'Bender',
@@ -144,7 +145,7 @@ describe('tracer should', () => {
   it('report a span with no tracer level tags', () => {
     let span = tracer.startSpan('op-name');
     tracer._report(span);
-    assert.isOk(reporter.spans.length, 1);
+    assert.equal(1, reporter.spans.length);
     let actualTags = _.sortBy(span._tags, o => {
       return o.key;
     });
@@ -164,7 +165,7 @@ describe('tracer should', () => {
 
     assert.equal(span.context().traceId, span.context().spanId);
     assert.equal(span.context().parentId, null);
-    assert.isOk(span.context().isSampled());
+    assert.isTrue(span.context().isSampled());
     assert.equal(span._startTime, startTime);
   });
 
@@ -412,7 +413,7 @@ describe('tracer should', () => {
         });
 
         _.each(o.metrics, metricName => {
-          assert.isOk(LocalBackend.counterEquals(metrics[metricName], 1));
+          assert.isTrue(LocalBackend.counterEquals(metrics[metricName], 1));
         });
       });
     });
@@ -425,7 +426,7 @@ describe('tracer should', () => {
       let span = tracer.startSpan('bender');
       tracer._report(span);
 
-      assert.isOk(LocalBackend.counterEquals(metrics.spansFinished, 1));
+      assert.isTrue(LocalBackend.counterEquals(metrics.spansFinished, 1));
     });
   });
 

--- a/test/udp_sender.js
+++ b/test/udp_sender.js
@@ -87,7 +87,6 @@ describe('udp sender', () => {
     server.on('message', (msg, remote) => {
       let thriftObj = thrift.Agent.emitBatch.argumentsMessageRW.readFrom(msg, 0);
       let batch = thriftObj.value.body.batch;
-      assert.isOk(batch);
       assert.equal(batch.spans.length, 2);
 
       assertThriftSpanEqual(assert, spanOne, batch.spans[0]);
@@ -143,7 +142,6 @@ describe('udp sender', () => {
           let thriftObj = thrift.Agent.emitBatch.argumentsMessageRW.readFrom(msg, 0);
           let batch = thriftObj.value.body.batch;
 
-          assert.isOk(batch);
           assertThriftSpanEqual(assert, tSpan, batch.spans[0]);
           if (o.expectedTraceId) {
             assert.deepEqual(batch.spans[0].traceIdLow, o.expectedTraceId);
@@ -261,7 +259,7 @@ describe('udp sender', () => {
         console.log('sender info: ' + msg);
       },
       error: msg => {
-        assert.isOk(expectLogs);
+        assert.isTrue(expectLogs);
         expect(msg).to.have.string('error sending spans over UDP: Error: getaddrinfo ENOTFOUND');
         tracer.close(done);
       },

--- a/test/zipkin_b3_text_map_codec.js
+++ b/test/zipkin_b3_text_map_codec.js
@@ -51,8 +51,8 @@ describe('Zipkin B3 Text Map Codec should', () => {
 
     let context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
 
-    assert.isOk(context);
-    assert.isOk(LocalBackend.counterEquals(metrics.decodingErrors, 1));
+    assert.isNotNull(context);
+    assert.isTrue(LocalBackend.counterEquals(metrics.decodingErrors, 1));
   });
 
   it('set debug flag when debug-id-header is received', () => {
@@ -85,7 +85,7 @@ describe('Zipkin B3 Text Map Codec should', () => {
     testCases.forEach(testCase => {
       let context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, testCase);
 
-      assert.isOk(context);
+      assert.isNotNull(context);
       assert.equal('', context.spanIdStr);
       assert.equal('', context.traceIdStr);
       assert.equal('', context.parentIdStr);
@@ -108,12 +108,12 @@ describe('Zipkin B3 Text Map Codec should', () => {
 
     const context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
 
-    assert.isOk(context.traceIdStr);
-    assert.isOk(context.spanIdStr);
-    assert.isOk(context.parentIdStr);
-    assert.isOk(context.isSampled());
-    assert.isOk(context.isDebug());
-    assert.isOk(context.debugId);
+    assert.equal('123abc', context.traceIdStr);
+    assert.equal('456def', context.spanIdStr);
+    assert.equal('789ghi', context.parentIdStr);
+    assert.isTrue(context.isSampled());
+    assert.isTrue(context.isDebug());
+    assert.equal('678pqr', context.debugId);
   });
 
   it('set the sampled flag when the zipkin sampled header is received', () => {
@@ -122,7 +122,7 @@ describe('Zipkin B3 Text Map Codec should', () => {
     };
 
     let context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
-    assert.isOk(context.isSampled());
+    assert.isTrue(context.isSampled());
     assert.isFalse(context.isDebug());
   });
 
@@ -141,7 +141,7 @@ describe('Zipkin B3 Text Map Codec should', () => {
     };
 
     let context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
-    assert.isOk(context.isSampled());
+    assert.isTrue(context.isSampled());
   });
 
   it('handle false value for the sampled header', () => {
@@ -159,8 +159,8 @@ describe('Zipkin B3 Text Map Codec should', () => {
     };
 
     let context = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, headers);
-    assert.isOk(context.isSampled());
-    assert.isOk(context.isDebug());
+    assert.isTrue(context.isSampled());
+    assert.isTrue(context.isDebug());
 
     headers = {
       'x-b3-flags': '0',


### PR DESCRIPTION
assert.isOk can match too many conditions, sometimes giving false positives in the tests.

Change to use more precise asserts, like isTrue when checking boolean fields.
