### PR TITLE
Fix buffer overflow in UDPSender

### DIFF
--- a/src/reporters/udp_sender.js
+++ b/src/reporters/udp_sender.js
@@ -113,11 +113,27 @@ export default class UDPSender {
       return;
     }
 
-    this.flush((numSpans: number, err?: string) => {
-      // TODO theoretically we can have buffer overflow here too, if many spans were appended during flush()
-      this._batch.spans.push(span);
-      this._totalSpanBytes += spanSize;
-      SenderUtils.invokeCallback(callback, numSpans, err);
+    this.flushWithPendingSpan(span, spanSize, callback);
+  }
+
+  flushWithPendingSpan(span, spanSize, callback){
+    this.flush((numSpans, err) => {
+      //Test totalSpanBytes before push
+      if(this._totalSpanBytes + spanSize <= this._maxSpanBytes) {
+        this._batch.spans.push(span);
+        this._totalSpanBytes += spanSize;
+
+        if (this._totalSpanBytes < this._maxSpanBytes) {
+          // still have space in the buffer, don't flush it yet
+          SenderUtils.invokeCallback(callback, numSpans, err);
+          return;
+        }
+        // buffer size === this._maxSpanBytes
+        this.flush(callback);
+      }else{
+        //Not enough space so we call recursively flushWithPendingSpan
+        this.flushWithPendingSpan(span, spanSize, callback);
+      }
     });
   }
 


### PR DESCRIPTION
Buffer overflow fix

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Resolves #382 
-

## Short description of the changes
Added a new function to flush with a pending span : add a new totalSpanBytes test before span push on flush end, if we have enough space we push the pending span to spans array, if not, we recursively call the new flushWithPendingSpan function. 

That solved the problem for me, but maybe isn't the best way to do. No unit tests, it's just for code comparison.
-
