### PR TITLE
Add option to share the ids from the parent for rpc servers

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -197,7 +197,9 @@ export default class Configuration {
    * @param {Object} [options.tags] - set of key-value pairs which will be set
    *        as process-level tags on the Tracer itself.
    * @param {boolean} [options.traceId128bit] - generate root span with a 128bit traceId.
+   * @param {boolean} [options.shareRpcSpan] - Share the same span for rpc span_kind.
    */
+
   static initTracer(config, options = {}) {
     let reporter;
     let sampler;
@@ -240,6 +242,7 @@ export default class Configuration {
       logger: options.logger,
       tags: options.tags,
       traceId128bit: options.traceId128bit,
+      shareRpcSpan: options.shareRpcSpan,
       debugThrottler: throttler,
     });
   }


### PR DESCRIPTION
Signed-off-by: Jonathan Monette <jon.monette@gmail.com>

## Which problem is this PR solving?

- Fixes: #400 

## Short description of the changes

- Added a configuration option to share the parendId and spanId between the child and parent for span.kind=rpc.  This was already implemented in the java tracer but the node tracer seems to be missing this option.   Java configuration for reference: https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java#L613-L616
