### PR TITLE
Do not apply adaptive sampler to child spans

### DIFF
--- a/src/samplers/per_operation_sampler.js
+++ b/src/samplers/per_operation_sampler.js
@@ -96,7 +96,8 @@ export default class PerOperationSampler implements Sampler {
       return { sample: false, retryable: false, tags: outTags };
     }
     let isSampled = this.isSampled(span.operationName, outTags);
-    // returning retryable=true since we can change decision after setOperationName().
+    // returning retryable=true since we can change the sampling decision
+    // after the first call to setOperationName()
     return { sample: isSampled, retryable: true, tags: outTags };
   }
 

--- a/src/samplers/per_operation_sampler.js
+++ b/src/samplers/per_operation_sampler.js
@@ -92,13 +92,19 @@ export default class PerOperationSampler implements Sampler {
 
   onCreateSpan(span: Span): SamplingDecision {
     const outTags = {};
-    const isSampled = this.isSampled(span.operationName, outTags);
-    // NB: return retryable=true here since we can change decision after setOperationName().
+    if (!span.context()._samplingState.isLocalRootSpan(span.context())) {
+      return { sample: false, retryable: false, tags: outTags };
+    }
+    let isSampled = this.isSampled(span.operationName, outTags);
+    // returning retryable=true since we can change decision after setOperationName().
     return { sample: isSampled, retryable: true, tags: outTags };
   }
 
   onSetOperationName(span: Span, operationName: string): SamplingDecision {
     const outTags = {};
+    if (!span.context()._samplingState.isLocalRootSpan(span.context())) {
+      return { sample: false, retryable: false, tags: outTags };
+    }
     const isSampled = this.isSampled(span.operationName, outTags);
     return { sample: isSampled, retryable: false, tags: outTags };
   }

--- a/src/samplers/per_operation_sampler.js
+++ b/src/samplers/per_operation_sampler.js
@@ -92,10 +92,10 @@ export default class PerOperationSampler implements Sampler {
 
   onCreateSpan(span: Span): SamplingDecision {
     const outTags = {};
-    if (!span.context()._samplingState.isLocalRootSpan(span.context())) {
-      return { sample: false, retryable: false, tags: outTags };
+    let isSampled = false;
+    if (span.context()._samplingState.isLocalRootSpan(span.context())) {
+      isSampled = this.isSampled(span.operationName, outTags);
     }
-    let isSampled = this.isSampled(span.operationName, outTags);
     // returning retryable=true since we can change the sampling decision
     // after the first call to setOperationName()
     return { sample: isSampled, retryable: true, tags: outTags };
@@ -103,10 +103,10 @@ export default class PerOperationSampler implements Sampler {
 
   onSetOperationName(span: Span, operationName: string): SamplingDecision {
     const outTags = {};
-    if (!span.context()._samplingState.isLocalRootSpan(span.context())) {
-      return { sample: false, retryable: false, tags: outTags };
+    let isSampled = false;
+    if (span.context()._samplingState.isLocalRootSpan(span.context())) {
+      isSampled = this.isSampled(span.operationName, outTags);
     }
-    const isSampled = this.isSampled(span.operationName, outTags);
     return { sample: isSampled, retryable: false, tags: outTags };
   }
 

--- a/test/samplers/remote_sampler.js
+++ b/test/samplers/remote_sampler.js
@@ -226,14 +226,19 @@ describe('RemoteSampler', () => {
       sp1.setOperationName('op2');
       assert.isTrue(sp1.context().isSampled(), 'op2 should be sampled on the root span');
 
-      let parent = tracer.startSpan('op1', 'op1 should not be sampled');
-      assert.isFalse(parent.context().isSampled());
-      assert.isFalse(parent.context().samplingFinalized);
+      let parent = tracer.startSpan('op1');
+      assert.isFalse(parent.context().isSampled(), 'parent span should not be sampled');
+      assert.isFalse(parent.context().samplingFinalized, 'parent span should not be finalized');
 
       let child = tracer.startSpan('op2', { childOf: parent });
-      assert.isFalse(child.context().isSampled(), 'op2 should not be sampled on the child span');
+      assert.isFalse(child.context().isSampled(), 'child span should not be sampled even with op2');
+      assert.isFalse(child.context().samplingFinalized, 'child span should not be finalized');
       child.setOperationName('op2');
       assert.isFalse(child.context().isSampled(), 'op2 should not be sampled on the child span');
+      assert.isTrue(
+        child.context().samplingFinalized,
+        'child span should be finalized after setOperationName'
+      );
 
       done();
     };

--- a/test/samplers/remote_sampler.js
+++ b/test/samplers/remote_sampler.js
@@ -221,6 +221,11 @@ describe('RemoteSampler', () => {
       let sp0 = tracer.startSpan('op2');
       assert.isTrue(sp0.context().isSampled(), 'op2 should be sampled on the root span');
 
+      sp0 = tracer.startSpan('op1');
+      assert.isFalse(sp0.context().isSampled(), 'op1 should not be sampled');
+      sp0.setOperationName('op2');
+      assert.isTrue(sp0.context().isSampled(), 'op2 should be sampled on the root span');
+
       let sp1 = tracer.startSpan('op1', 'op1 should not be sampled');
       assert.isFalse(sp1.context().isSampled());
       let sp2 = tracer.startSpan('op2', { childOf: sp1 });

--- a/test/samplers/remote_sampler.js
+++ b/test/samplers/remote_sampler.js
@@ -221,17 +221,19 @@ describe('RemoteSampler', () => {
       let sp0 = tracer.startSpan('op2');
       assert.isTrue(sp0.context().isSampled(), 'op2 should be sampled on the root span');
 
-      sp0 = tracer.startSpan('op1');
-      assert.isFalse(sp0.context().isSampled(), 'op1 should not be sampled');
-      sp0.setOperationName('op2');
-      assert.isTrue(sp0.context().isSampled(), 'op2 should be sampled on the root span');
+      let sp1 = tracer.startSpan('op1');
+      assert.isFalse(sp1.context().isSampled(), 'op1 should not be sampled');
+      sp1.setOperationName('op2');
+      assert.isTrue(sp1.context().isSampled(), 'op2 should be sampled on the root span');
 
-      let sp1 = tracer.startSpan('op1', 'op1 should not be sampled');
-      assert.isFalse(sp1.context().isSampled());
-      let sp2 = tracer.startSpan('op2', { childOf: sp1 });
-      assert.isFalse(sp1.context().isSampled(), 'op2 should not be sampled on the child span');
-      sp2.setOperationName('op2');
-      assert.isFalse(sp1.context().isSampled(), 'op2 should not be sampled on the child span');
+      let parent = tracer.startSpan('op1', 'op1 should not be sampled');
+      assert.isFalse(parent.context().isSampled());
+      assert.isFalse(parent.context().samplingFinalized);
+
+      let child = tracer.startSpan('op2', { childOf: parent });
+      assert.isFalse(child.context().isSampled(), 'op2 should not be sampled on the child span');
+      child.setOperationName('op2');
+      assert.isFalse(child.context().isSampled(), 'op2 should not be sampled on the child span');
 
       done();
     };

--- a/test/samplers/remote_sampler.js
+++ b/test/samplers/remote_sampler.js
@@ -198,7 +198,7 @@ describe('RemoteSampler', () => {
     server.addStrategy('service1', {
       strategyType: 'PROBABILISTIC',
       probabilisticSampling: {
-        samplingRate: 1.0,
+        samplingRate: 0.0,
       },
       operationSampling: {
         defaultSamplingProbability: 0.05,
@@ -224,6 +224,8 @@ describe('RemoteSampler', () => {
       let sp1 = tracer.startSpan('op1', 'op1 should not be sampled');
       assert.isFalse(sp1.context().isSampled());
       let sp2 = tracer.startSpan('op2', { childOf: sp1 });
+      assert.isFalse(sp1.context().isSampled(), 'op2 should not be sampled on the child span');
+      sp2.setOperationName('op2');
       assert.isFalse(sp1.context().isSampled(), 'op2 should not be sampled on the child span');
 
       done();


### PR DESCRIPTION
## Which problem is this PR solving?

Per-operation adaptive sampling should only apply to service endpoints, not to operation names of the inner/children spans. Recent changes (e.g. #380) broke that functionality and traces can now be sampled by the per-operation sampler triggering on children spans. This is a problem for adaptive sampling backend that only records operations from the root spans, meaning all child operations are getting the default probability, which may be higher than the calculated probabilities.

## Short description of the changes

- Add a test that demonstrates the problem.
- Change per-operation sampler to only allow sampling "local root spans", which is equivalent to the actual root span of the trace because spans with remote parent are finalized right away.