### PR TITLE
[HTTPSender] Clear span buffer if Thrift encoding fails

### DIFF
--- a/src/reporters/http_sender.js
+++ b/src/reporters/http_sender.js
@@ -102,13 +102,12 @@ export default class HTTPSender {
     }
 
     const result = this._jaegerThrift.Batch.rw.toBuffer(this._batch);
+    this._reset(); // clear buffer for new spans, even if Thrift conversion fails
+
     if (result.err) {
-      this._reset();
       SenderUtils.invokeCallback(callback, numSpans, `Error encoding Thrift batch: ${result.err}`);
       return;
     }
-
-    this._reset();
 
     const requester = this._url.protocol === 'https:' ? https.request : http.request;
 

--- a/src/reporters/http_sender.js
+++ b/src/reporters/http_sender.js
@@ -103,6 +103,7 @@ export default class HTTPSender {
 
     const result = this._jaegerThrift.Batch.rw.toBuffer(this._batch);
     if (result.err) {
+      this._reset();
       SenderUtils.invokeCallback(callback, numSpans, `Error encoding Thrift batch: ${result.err}`);
       return;
     }

--- a/test/http_sender.js
+++ b/test/http_sender.js
@@ -284,44 +284,4 @@ describe('http sender', () => {
       done();
     });
   });
-
-  it('should avoid OOM on failed buffer conversion', done => {
-    function createSpan(name) {
-      const span = tracer.startSpan(name);
-      span.finish(); // finish to set span duration
-      return span;
-    }
-
-    const maxSpanBatchSize = 5;
-
-    sender = new HTTPSender({
-      endpoint: serverEndpoint,
-      maxSpanBatchSize,
-    });
-    sender.setProcess(reporter._process);
-
-    // simulate the server use jaeger client keep sending data
-    let num = 0;
-    const intervalHandle = setInterval(() => {
-      if (num === 14) {
-        const wrongSpan = createSpan(); // name is required, make a mistake in create span
-        sender.append(ThriftUtils.spanToThrift(wrongSpan)); // append dirty span to the send queue, it will cause serialization error in flush
-      } else {
-        sender.append(ThriftUtils.spanToThrift(createSpan(num)));
-      }
-      num++;
-    }, 1);
-
-    setTimeout(() => {
-      clearInterval(intervalHandle);
-
-      // check spans length in the send queue
-      assert.equal(sender._batch.spans.length < maxSpanBatchSize, true);
-
-      sender.flush((numSpans, err) => {
-        assert.equal(sender._batch.spans.length, 0);
-        done();
-      });
-    }, 3000);
-  }).timeout(5000);
 });


### PR DESCRIPTION
Resolves #414 

HTTPSender empty the send queue when catch error to avoid OOM