### PR TITLE
Generate JavaScript module from thrift IDLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ coverage/
 node_modules/
 npm-debug.log
 dist/
+src/generated/
 
 .idea/
 *.iml

--- a/Makefile
+++ b/Makefile
@@ -58,14 +58,11 @@ build-node: check-node-lts node-modules build-without-install
 .PHONY: build-without-install
 build-without-install:
 	rm -rf ./dist/
+	npm run generate-thrift
 	node_modules/.bin/babel --presets env --plugins transform-class-properties --source-maps -d dist/src/ src/
 	node_modules/.bin/babel --presets env --plugins transform-class-properties --source-maps -d dist/test/ test/
 	node_modules/.bin/babel --presets env --plugins transform-class-properties --source-maps -d dist/crossdock/ crossdock/
 	cat src/version.js | sed "s|VERSION_TBD|$(shell node -p 'require("./package.json").version')|g" > dist/src/version.js
-	cp -R ./test/thrift ./dist/test/thrift/
-	cp -R ./src/jaeger-idl ./dist/src/
-	rm -rf ./dist/src/jaeger-idl/.git
-	cp -R ./src/thriftrw-idl ./dist/src/
 
 .PHONY: node-modules
 node-modules:

--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ let server = new TChannel({ serviceName: 'server' });
 server.listen(4040, '127.0.0.1');
 let serverThriftChannel = TChannelAsThrift({
   channel: server,
-  entryPoint: path.join(__dirname, 'thrift', 'echo.thrift'), // file path to a thrift file
+  entryPoint: 'thrift/echo.thrift', //  path to a thrift IDL
+  idls: ThriftData,
 });
 
 let perProcessOptions = {};
@@ -168,6 +169,7 @@ Outbound calls can be made in two ways, shown below.
 
 ```javascript
 import { TChannelBridge } from 'jaeger-client';
+import ThriftData from './generated/thrift';
 
 let bridge = new TChannelBridge(tracer);
 // Create the toplevel client channel.
@@ -181,7 +183,8 @@ let clientSubChannel = client.makeSubChannel({
 
 let encodedThriftChannel = TChannelAsThrift({
   channel: clientSubChannel,
-  entryPoint: path.join(__dirname, 'thrift', 'echo.thrift'), // file path to a thrift file
+  entryPoint: 'thrift/echo.thrift', // path to a thrift IDL
+  idls: ThriftData,
 });
 
 // wrap encodedThriftChannel in a tracing decorator

--- a/README.md
+++ b/README.md
@@ -148,8 +148,7 @@ let server = new TChannel({ serviceName: 'server' });
 server.listen(4040, '127.0.0.1');
 let serverThriftChannel = TChannelAsThrift({
   channel: server,
-  entryPoint: 'thrift/echo.thrift', //  path to a thrift IDL
-  idls: ThriftData,
+  entryPoint: path.join(__dirname, 'thrift', 'echo.thrift'), // file path to a thrift file
 });
 
 let perProcessOptions = {};
@@ -169,7 +168,6 @@ Outbound calls can be made in two ways, shown below.
 
 ```javascript
 import { TChannelBridge } from 'jaeger-client';
-import ThriftData from './generated/thrift';
 
 let bridge = new TChannelBridge(tracer);
 // Create the toplevel client channel.
@@ -183,8 +181,7 @@ let clientSubChannel = client.makeSubChannel({
 
 let encodedThriftChannel = TChannelAsThrift({
   channel: clientSubChannel,
-  entryPoint: 'thrift/echo.thrift', // path to a thrift IDL
-  idls: ThriftData,
+  entryPoint: path.join(__dirname, 'thrift', 'echo.thrift'), // file path to a thrift file
 });
 
 // wrap encodedThriftChannel in a tracing decorator

--- a/crossdock/src/helpers.js
+++ b/crossdock/src/helpers.js
@@ -12,7 +12,6 @@
 // the License.
 
 import * as constants from './constants.js';
-import fs from 'fs';
 import path from 'path';
 import dns from 'dns';
 import DefaultContext from '../../src/default_context';
@@ -26,6 +25,7 @@ import TChannel from 'tchannel/channel';
 import TChannelThrift from 'tchannel/as/thrift';
 import TChannelBridge from '../../src/tchannel_bridge';
 import Utils from '../../src/util.js';
+import ThriftData from '../../src/generated/thrift';
 
 export default class Helpers {
   _tracer: Tracer;
@@ -40,13 +40,10 @@ export default class Helpers {
       peers: [Utils.myIp() + ':8082'],
     });
 
-    let crossdockSpec = fs.readFileSync(
-      path.join(__dirname, '..', '..', 'src', 'jaeger-idl', 'thrift', 'crossdock', 'tracetest.thrift'),
-      'utf8'
-    );
+    let crossdockSpec = ThriftData['jaeger-idl/thrift/crossdock/tracetest.thrift'];
     let thriftChannel = TChannelThrift({
       channel: channel,
-      source: crossdockSpec,
+      source: ThriftData[crossdockSpec],
     });
 
     let bridge = new TChannelBridge(this._tracer);

--- a/crossdock/src/tchannel_server.js
+++ b/crossdock/src/tchannel_server.js
@@ -36,14 +36,10 @@ export default class TChannelServer {
     this._helpers = new Helpers(this._tracer);
 
     let serverChannel = TChannel({ serviceName: 'node' });
-
     let tchannelThrift = TChannelThrift({
       channel: serverChannel,
       source:
-        ThriftData[crossdockSpecPath] ||
-        (() => {
-          throw new Error(`${crossdockSpecPath} not found`);
-        }),
+        ThriftData[crossdockSpecPath],
     });
     let context = new DefaultContext();
 

--- a/crossdock/src/tchannel_server.js
+++ b/crossdock/src/tchannel_server.js
@@ -24,6 +24,7 @@ import TChannelBridge from '../../src/tchannel_bridge';
 import TChannel from 'tchannel';
 import TChannelThrift from 'tchannel/as/thrift';
 import Utils from '../../src/util.js';
+import ThriftData from '../../src/generated/thrift';
 
 let DEFAULT_THRIFT_PATH = '/crossdock/tracetest.thrift';
 export default class TChannelServer {
@@ -35,9 +36,14 @@ export default class TChannelServer {
     this._helpers = new Helpers(this._tracer);
 
     let serverChannel = TChannel({ serviceName: 'node' });
+
     let tchannelThrift = TChannelThrift({
       channel: serverChannel,
-      entryPoint: crossdockSpecPath,
+      source:
+        ThriftData[crossdockSpecPath] ||
+        (() => {
+          throw new Error(`${crossdockSpecPath} not found`);
+        }),
     });
     let context = new DefaultContext();
 

--- a/crossdock/test/endtoend_handler.js
+++ b/crossdock/test/endtoend_handler.js
@@ -12,7 +12,6 @@
 
 import { assert } from 'chai';
 import dgram from 'dgram';
-import fs from 'fs';
 import EndToEndHandler from '../src/endtoend_handler';
 import path from 'path';
 import request from 'request';
@@ -20,6 +19,7 @@ import JaegerTestUtils from '../../src/test_util';
 import { Thrift } from 'thriftrw';
 import bodyParser from 'body-parser';
 import express from 'express';
+import { ThriftData } from '../../src/generated/thrift';
 
 const PORT = 6832;
 const HOST = '127.0.0.1';
@@ -32,9 +32,9 @@ describe('Endtoend Handler should', () => {
     server = dgram.createSocket('udp4');
     server.bind(PORT, HOST);
     thrift = new Thrift({
-      entryPoint: path.join(__dirname, '../../src/thriftrw-idl/agent.thrift'),
+      entryPoint: 'thriftrw-idl/agent.thrift',
+      idls: ThriftData,
       allowOptionalArguments: true,
-      allowFilesystemAccess: true,
     });
 
     let handler = new EndToEndHandler({ port: PORT, host: HOST });

--- a/crossdock/test/tchannel_server.js
+++ b/crossdock/test/tchannel_server.js
@@ -23,9 +23,9 @@ import TChannelServer from '../src/tchannel_server.js';
 import TChannelAsThrift from 'tchannel/as/thrift';
 import TChannel from 'tchannel';
 import Tracer from '../../src/tracer.js';
-import fs from 'fs';
 import path from 'path';
 import Utils from '../../src/util.js';
+import ThriftData from '../../src/generated/thrift';
 
 process.env.NODE_ENV = 'test';
 
@@ -36,16 +36,7 @@ describe('crossdock tchannel server should', () => {
   let server;
   let tracer;
   let bridge;
-  let crossdockSpecPath = path.join(
-    __dirname,
-    '..',
-    '..',
-    'src',
-    'jaeger-idl',
-    'thrift',
-    'crossdock',
-    'tracetest.thrift'
-  );
+  let crossdockSpecPath = 'jaeger-idl/thrift/crossdock/tracetest.thrift';
 
   before(() => {
     tracer = new Tracer('node', new InMemoryReporter(), new ConstSampler(false));
@@ -68,6 +59,7 @@ describe('crossdock tchannel server should', () => {
       let thriftChannel = TChannelAsThrift({
         channel: requestChannel,
         entryPoint: crossdockSpecPath,
+        idls: ThriftData,
       });
       let tracedChannel = bridge.tracedChannel(thriftChannel);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jaeger-client",
-  "version": "3.17.2dev",
+  "version": "3.17.3dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1065,6 +1065,12 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "dev": true
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1098,10 +1104,13 @@
       "optional": true
     },
     "bindings": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
-      "dev": true
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "1.1.2",
@@ -1220,6 +1229,16 @@
       "requires": {
         "caniuse-lite": "^1.0.30000844",
         "electron-to-chromium": "^1.3.47"
+      }
+    },
+    "buffer": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-from": {
@@ -1629,10 +1648,13 @@
       }
     },
     "crc": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz",
-      "integrity": "sha1-XZyPt3okXNXsopHl0tAFM0urAII=",
-      "dev": true
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.1.0"
+      }
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -2619,12 +2641,12 @@
       "dev": true
     },
     "farmhash": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/farmhash/-/farmhash-1.1.0.tgz",
-      "integrity": "sha1-8Qeb+4JOlg0wSthejfxa+zdA7ZI=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/farmhash/-/farmhash-1.2.1.tgz",
+      "integrity": "sha1-Lb8SYE71yh8UIPtmAPzLMNVHTf0=",
       "dev": true,
       "requires": {
-        "nan": "^2.0.5"
+        "nan": "^2.4.0"
       }
     },
     "fast-deep-equal": {
@@ -2664,6 +2686,12 @@
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -3753,6 +3781,26 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "hexer": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/hexer/-/hexer-1.5.0.tgz",
+      "integrity": "sha1-uGzoCFmOip0YksVx887dhvyfBlM=",
+      "dev": true,
+      "requires": {
+        "ansi-color": "^0.2.1",
+        "minimist": "^1.1.0",
+        "process": "^0.10.0",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "process": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz",
+          "integrity": "sha1-hCRXzFHP7XLcd1r+6vuMYDQ3JyU=",
+          "dev": true
+        }
+      }
+    },
     "hoek": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
@@ -3826,6 +3874,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
     },
     "ignore": {
       "version": "3.3.10",
@@ -5168,6 +5222,12 @@
         }
       }
     },
+    "mock-fs": {
+      "version": "4.10.4",
+      "resolved": "https://artifacts.prd.costargroup.com/artifactory/api/npm/csgp-npm/mock-fs/-/mock-fs-4.10.4.tgz",
+      "integrity": "sha1-Tqo9b32i9E4fPda0Ysu8t7CC49Q=",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -5780,9 +5840,9 @@
       "dev": true
     },
     "process": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz",
-      "integrity": "sha1-7jvstDNe3zyLFMy/fhehElpEMa4=",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "process-nextick-args": {
@@ -6928,19 +6988,19 @@
       "dev": true
     },
     "sse4_crc32": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/sse4_crc32/-/sse4_crc32-5.3.0.tgz",
-      "integrity": "sha512-AgnPwYR3ABQHRz1VKir0Ftcvz831tEd7ggwXkuTh1ULcDS6GMAioICCCnMj6YBmVnYbaeuePInqM7jrGuTencA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/sse4_crc32/-/sse4_crc32-5.4.0.tgz",
+      "integrity": "sha512-sNCs25xYaKRyMcqUNej7NATXQDkSaRlh6cqd/0KzboDKIqvVG30BnRZP295U/GliTmTCBkYS7Wl9mw7a76bKIQ==",
       "dev": true,
       "requires": {
-        "bindings": "~1.2.1",
-        "nan": "2.11.0"
+        "bindings": "~1.5.0",
+        "nan": "2.14.0"
       },
       "dependencies": {
         "nan": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-          "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
           "dev": true
         }
       }
@@ -7197,29 +7257,56 @@
       "dev": true
     },
     "tchannel": {
-      "version": "3.9.13",
-      "resolved": "https://registry.npmjs.org/tchannel/-/tchannel-3.9.13.tgz",
-      "integrity": "sha512-NdlwYLNxkrQwT2QmriMQ/LvlPq9j99Awpzk3VtTECNOqSGmMOK6TZjrCUU2L8PPTZXfg380LcSzdxvV982HQWg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/tchannel/-/tchannel-3.10.1.tgz",
+      "integrity": "sha512-hC5Ju9erF4DGBppnrhD+DEBKXvRJMU1EVq1ukKYgTR+8NJ5WBGmmTHdL9oMd76PyWpeOkKV2qXp9IQ64zzJ4Rw==",
       "dev": true,
       "requires": {
         "bufrw": "^1.2.1",
-        "crc": "3.2.1",
+        "crc": "^3.8.0",
         "error": "^7.0.1",
-        "farmhash": "1.1.0",
+        "farmhash": "^1",
         "json-stringify-safe": "^5.0.0",
         "metrics": "^0.1.8",
         "minimist": "^1.1.0",
-        "process": "0.11.1",
+        "process": "^0.11.10",
         "raw-body": "^2.1.2",
         "ready-signal": "^1.1.1",
         "run-parallel": "^1.1.0",
         "run-series": "^1.1.2",
         "safe-json-parse": "^4.0.0",
-        "sse4_crc32": "^5.3.0",
+        "sse4_crc32": "^5",
         "tape-cluster": "2.1.0",
-        "thriftrw": "^3.11.0",
+        "thriftrw": "^3.12.0",
         "xorshift": "^0.2.0",
         "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "thriftrw": {
+          "version": "3.12.0",
+          "resolved": "https://registry.npmjs.org/thriftrw/-/thriftrw-3.12.0.tgz",
+          "integrity": "sha512-4YZvR4DPEI41n4Opwr4jmrLGG4hndxr7387kzRFIIzxHQjarPusH4lGXrugvgb7TtPrfZVTpZCVe44/xUxowEw==",
+          "dev": true,
+          "requires": {
+            "bufrw": "^1.3.0",
+            "error": "7.0.2",
+            "long": "^2.4.0"
+          },
+          "dependencies": {
+            "bufrw": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/bufrw/-/bufrw-1.3.0.tgz",
+              "integrity": "sha512-jzQnSbdJqhIltU9O5KUiTtljP9ccw2u5ix59McQy4pV2xGhVLhRZIndY8GIrgh5HjXa6+QJ9AQhOd2QWQizJFQ==",
+              "dev": true,
+              "requires": {
+                "ansi-color": "^0.2.1",
+                "error": "^7.0.0",
+                "hexer": "^1.5.0",
+                "xtend": "^4.0.0"
+              }
+            }
+          }
+        }
       }
     },
     "text-table": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "lodash": "^4.15.0",
     "minimist": "1.2.0",
     "mocha": "^3.0.1",
+    "mock-fs": "^4.10.4",
     "prettier": "1.10.2",
     "request": "2.74.0",
     "rsvp": "^3.3.1",
@@ -75,7 +76,8 @@
     "test-throttler": "mocha --compilers js:babel-core/register test/throttler",
     "test-prom-metrics": "mocha --compilers js:babel-core/register test/metrics",
     "test-crossdock": "mocha --compilers js:babel-register crossdock/test",
-    "show-cover": "open coverage/lcov-report/index.html"
+    "show-cover": "open coverage/lcov-report/index.html",
+    "generate-thrift": "node scripts/javascriptifier-cli"
   },
   "lint-staged": {
     "*.{js,json,md}": ["prettier --write", "git add"]

--- a/scripts/javascriptifier-cli.js
+++ b/scripts/javascriptifier-cli.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, The Jaeger Authors
+// Copyright (c) 2020, The Jaeger Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at

--- a/scripts/javascriptifier-cli.js
+++ b/scripts/javascriptifier-cli.js
@@ -1,0 +1,33 @@
+// Copyright (c) 2017, The Jaeger Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+/* eslint-disable no-console */
+
+/**
+ * Converts thrift IDL files to a javascript module
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+const { generateJavascriptFromThrift } = require('./lib/javascriptifier');
+
+const rootPath = path.resolve(__dirname, '../src');
+const targetDir = path.resolve(rootPath, 'generated');
+const targetFile = path.resolve(targetDir, 'thrift.js');
+const inputDirs = [path.resolve(rootPath, `thriftrw-idl`), path.resolve(rootPath, 'jaeger-idl/thrift')];
+
+if (!fs.existsSync(targetDir)) {
+  fs.mkdirSync(targetDir);
+}
+
+generateJavascriptFromThrift(inputDirs, targetFile, rootPath);

--- a/scripts/lib/javascriptifier.js
+++ b/scripts/lib/javascriptifier.js
@@ -102,6 +102,7 @@ function writeObjectAsJavascriptModule(obj /*: string */, targetPath /*: string 
     writeSync(handle, js);
   });
   writeSync(handle, getFooter());
+  closeSync(handle);
 }
 
 /**

--- a/scripts/lib/javascriptifier.js
+++ b/scripts/lib/javascriptifier.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, The Jaeger Authors
+// Copyright (c) 2020, The Jaeger Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at
@@ -113,8 +113,7 @@ function generateJavascriptKeyValuePair(name /*: string*/, data /*: string*/) {
 }
 
 function getHeader() {
-  return `
-/* eslint-disable camelcase */
+  return `/* eslint-disable camelcase */
 
 // GENERATED CODE - DO NOT MODIFY!
 

--- a/scripts/lib/javascriptifier.js
+++ b/scripts/lib/javascriptifier.js
@@ -1,0 +1,164 @@
+// Copyright (c) 2017, The Jaeger Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+const { lstatSync, openSync, writeSync, closeSync, readFileSync, readdirSync } = require('fs');
+const path = require('path');
+
+/**
+ * Convert all files in a directory recursively to a jso of structure:
+ *
+ * {
+ *    "filename": "file contents",
+ *    "dir/filename": "file contents"
+ * }
+ *
+ * "filename" is extensionless.
+ */
+function convertDirectoryToJavascriptObject(dirPath, root) {
+  const fileSpecs = getFileSpecsRecursively(dirPath, root);
+  return convertThriftFilesToJavascriptObject(fileSpecs);
+}
+
+/**
+ * Given a set of files, generate a JavaScript module with exports named for each relative path,
+ */
+function generateJavascriptFromThrift(filePaths, target, rootPath) {
+  const allFileSpecs = [];
+  filePaths.forEach(filePath => {
+    allFileSpecs.push(...getFileSpecsRecursively(filePath, rootPath));
+  });
+
+  const idls = convertThriftFilesToJavascriptObject(allFileSpecs);
+  writeObjectAsJavascriptModule(idls, target);
+}
+
+/**
+ * Collect specifications for each file in a hierarchy starting from dirPath,
+ * relative to rootPath.
+ */
+function getFileSpecsRecursively(dirPath /*: string */, rootPath /*: string */) /*: FileSpec[] */ {
+  const files = readdirSync(dirPath);
+  const outFiles /*: string[] */ = [];
+  const children /*: string[] */ = [];
+
+  const fileData = files
+    .filter(fileName => {
+      const stat = lstatSync(`${dirPath}/${fileName}`);
+      if (stat.isDirectory()) {
+        children.push(fileName);
+        return false;
+      }
+      outFiles.push(fileName);
+      return true;
+    })
+    .map(fileName => {
+      const filePath = `${dirPath}/${fileName}`;
+      const relativePath = slash(path.relative(rootPath, filePath));
+      return {
+        fileName,
+        filePath,
+        relativePath,
+      };
+    });
+
+  // recursively call for all directories we identified before and append to the output
+  const childData = children.map(fileName => getFileSpecsRecursively(`${dirPath}/${fileName}`, rootPath));
+  childData.forEach(data => fileData.push(...data));
+  return fileData;
+}
+
+/**
+ * Given a set of file specs as returned by getFileSpecsRecursively, generate a jso
+ * with exports named for the relative path to each file, and returning the data
+ * in each file.
+ */
+function convertThriftFilesToJavascriptObject(fileSpecs /*: FileSpec[] */) {
+  const out = {};
+  fileSpecs.forEach(spec => {
+    const data = readFileSync(spec.filePath, 'utf-8');
+    out[spec.relativePath] = data;
+  });
+  return out;
+}
+
+/**
+ * Given a jso, write it as a javascript module file with exports named for each key.
+ * This expects the content to be thrift IDLs and strips comments from the data.
+ */
+function writeObjectAsJavascriptModule(obj /*: string */, targetPath /*: string */) {
+  const handle = openSync(targetPath, 'w');
+  writeSync(handle, getHeader());
+  Object.entries(obj).forEach(([key, value]) => {
+    const js = generateJavascriptKeyValuePair(key, value);
+    writeSync(handle, js);
+  });
+  writeSync(handle, getFooter());
+}
+
+/**
+ * Format a key/value pair as a javascript object descriptor
+ */
+function generateJavascriptKeyValuePair(name /*: string*/, data /*: string*/) {
+  const dataJsLiteral = '`' + escapeTemplateLiteral(stripCommentsFromThrift(data)) + '`,\n';
+  return `"${name}": ${dataJsLiteral}`;
+}
+
+function getHeader() {
+  return `
+/* eslint-disable camelcase */
+
+// GENERATED CODE - DO NOT MODIFY!
+
+module.exports = {
+`;
+}
+
+function getFooter() {
+  return '};\n';
+}
+
+// for windows
+function slash(somePath) {
+  return somePath.replace(/\\/g, '/');
+}
+
+const commentRegexp = /^\s*(#|\/\*|\*|\*\/|\/\/).*$/;
+const inlineCommentRegexp = /^([^"']+)\s(#|\/\/).*$/;
+function stripCommentsFromThrift(text) {
+  return text
+    .split('\n')
+    .filter(line => !commentRegexp.test(line) && line.trim() !== '')
+    .map(line => {
+      const match = line.match(inlineCommentRegexp);
+      if (match) {
+        return match[1];
+      }
+      return line;
+    })
+    .join('\n');
+}
+
+function escapeTemplateLiteral(text) {
+  return text
+    .replace(/\\/g, '\\\\')
+    .replace(/\`/g, '\\`')
+    .replace(/\$\{/g, '\\${');
+}
+
+module.exports = {
+  stripCommentsFromThrift,
+  generateJavascriptFromThrift,
+  convertThriftFilesToJavascriptObject,
+  writeObjectAsJavascriptModule,
+  getFileSpecsRecursively,
+  convertDirectoryToJavascriptObject,
+};

--- a/src/reporters/http_sender.js
+++ b/src/reporters/http_sender.js
@@ -11,7 +11,6 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-import fs from 'fs';
 import http from 'http';
 import https from 'https';
 import path from 'path';
@@ -20,6 +19,7 @@ import { Thrift } from 'thriftrw';
 
 import NullLogger from '../logger.js';
 import SenderUtils from './sender_utils.js';
+import ThriftData from '../generated/thrift';
 
 const DEFAULT_PATH = '/api/traces';
 const DEFAULT_PORT = 14268;
@@ -55,7 +55,8 @@ export default class HTTPSender {
 
     this._logger = options.logger || new NullLogger();
     this._jaegerThrift = new Thrift({
-      source: fs.readFileSync(path.join(__dirname, '../jaeger-idl/thrift/jaeger.thrift'), 'ascii'),
+      entryPoint: 'jaeger-idl/thrift/jaeger.thrift',
+      idls: ThriftData,
       allowOptionalArguments: true,
     });
 

--- a/src/reporters/udp_sender.js
+++ b/src/reporters/udp_sender.js
@@ -12,12 +12,12 @@
 // the License.
 
 import dgram from 'dgram';
-import fs from 'fs';
 import path from 'path';
 import { Thrift } from 'thriftrw';
 import NullLogger from '../logger';
 import SenderUtils from './sender_utils';
 import Utils from '../util';
+import ThriftData from '../generated/thrift';
 
 const HOST = 'localhost';
 const PORT = 6832;
@@ -51,12 +51,13 @@ export default class UDPSender {
       this._logger.error(`error sending spans over UDP: ${err}`);
     });
     this._agentThrift = new Thrift({
-      entryPoint: path.join(__dirname, '../thriftrw-idl/agent.thrift'),
+      entryPoint: 'thriftrw-idl/agent.thrift',
+      idls: ThriftData,
       allowOptionalArguments: true,
-      allowFilesystemAccess: true,
     });
     this._jaegerThrift = new Thrift({
-      source: fs.readFileSync(path.join(__dirname, '../jaeger-idl/thrift/jaeger.thrift'), 'ascii'),
+      entryPoint: 'jaeger-idl/thrift/jaeger.thrift',
+      idls: ThriftData,
       allowOptionalArguments: true,
     });
     this._totalSpanBytes = 0;

--- a/src/thrift.js
+++ b/src/thrift.js
@@ -11,15 +11,16 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-import fs from 'fs';
 import opentracing from 'opentracing';
 import path from 'path';
 import { Thrift } from 'thriftrw';
 import Utils from './util.js';
+import ThriftData from './generated/thrift';
 
 export default class ThriftUtils {
   static _thrift = new Thrift({
-    source: fs.readFileSync(path.join(__dirname, './jaeger-idl/thrift/jaeger.thrift'), 'ascii'),
+    entryPoint: 'jaeger-idl/thrift/jaeger.thrift',
+    idls: ThriftData,
     allowOptionalArguments: true,
   });
   static emptyBuffer: Buffer = Utils.newBuffer(8);

--- a/test/http_sender.js
+++ b/test/http_sender.js
@@ -17,7 +17,6 @@ import { raw } from 'body-parser';
 import { assert, expect } from 'chai';
 import ConstSampler from '../src/samplers/const_sampler.js';
 import https from 'https';
-import fs from 'fs';
 import path from 'path';
 import semver from 'semver';
 import InMemoryReporter from '../src/reporters/in_memory_reporter.js';
@@ -27,6 +26,7 @@ import Tracer from '../src/tracer.js';
 import { Thrift } from 'thriftrw';
 import ThriftUtils from '../src/thrift.js';
 import HTTPSender from '../src/reporters/http_sender.js';
+import ThriftData from '../src/generated/thrift';
 
 const batchSize = 100;
 
@@ -53,7 +53,8 @@ describe('http sender', () => {
 
   beforeEach(() => {
     thrift = new Thrift({
-      source: fs.readFileSync(path.join(__dirname, '../src/jaeger-idl/thrift/jaeger.thrift'), 'ascii'),
+      entryPoint: 'jaeger-idl/thrift/jaeger.thrift',
+      idls: ThriftData,
       allowOptionalArguments: true,
     });
 

--- a/test/javascriptifier.js
+++ b/test/javascriptifier.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, The Jaeger Authors
+// Copyright (c) 2020, The Jaeger Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at

--- a/test/javascriptifier.js
+++ b/test/javascriptifier.js
@@ -1,0 +1,161 @@
+// Copyright (c) 2017, The Jaeger Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+import {
+  getFileSpecsRecursively,
+  convertThriftFilesToJavascriptObject,
+  writeObjectAsJavascriptModule,
+  stripCommentsFromThrift,
+} from '../scripts/lib/javascriptifier';
+import fs from 'fs';
+import mockfs from 'mock-fs';
+import uuid from 'uuid/v4';
+import assert from 'assert';
+
+// guard against accidentally failing to mock filesystem
+const mockRoot = `/${uuid()}`;
+
+describe('getFileSpecsRecursively', () => {
+  beforeEach(() => mockfs({ [mockRoot]: {} }));
+  afterEach(() => mockfs.restore());
+
+  it('works with no subdirectories', () => {
+    const fileNames = sequence(5)
+      .map(i => {
+        const fileName = `test-file-${i}.tst`;
+        fs.writeFileSync(`${mockRoot}/${fileName}`, `test-data-${i}`);
+        return fileName;
+      })
+      .sort();
+
+    const specs = getFileSpecsRecursively(mockRoot, mockRoot);
+    assert.deepEqual(specs.map(e => e.relativePath).sort(), fileNames, 'file paths match');
+  });
+
+  it('works with subdirectories', () => {
+    const expectedFilePaths = setUpNestedScenario(2, 5).sort();
+    const specs = getFileSpecsRecursively(mockRoot, mockRoot);
+
+    const actualFilePaths = specs.map(e => e.relativePath).sort();
+
+    assert.deepEqual(
+      expectedFilePaths,
+      actualFilePaths,
+      'file paths match what was returned by getFileSpecsRecursively'
+    );
+  });
+});
+
+describe('convertThriftFilesToJavascriptObject', () => {
+  beforeEach(() => mockfs({ [mockRoot]: {} }));
+  afterEach(() => mockfs.restore());
+
+  it('creates the object as expected', () => {
+    setUpNestedScenario(1, 3);
+    const specs = getFileSpecsRecursively(mockRoot, mockRoot);
+    const outfile = `${mockRoot}/out.js`;
+    const obj = convertThriftFilesToJavascriptObject(specs);
+
+    const allKeys = Object.keys(obj).sort();
+    assert.deepEqual(
+      allKeys,
+      ['dir-0/file-0.tst', 'dir-0/file-1.tst', 'dir-0/file-2.tst', 'file-0.tst', 'file-1.tst', 'file-2.tst'],
+      'generated module keys are as expected'
+    );
+
+    const expectedData = fs.readFileSync(`${mockRoot}/dir-0/file-1.tst`, 'ascii');
+    assert.equal(obj['dir-0/file-1.tst'], expectedData, 'data matches');
+  });
+});
+
+describe('writeObjectAsJavascriptModule', () => {
+  beforeEach(() => mockfs({ [mockRoot]: {} }));
+  afterEach(() => mockfs.restore());
+
+  it('writes file as expected', () => {
+    const obj = {
+      foo: 'abc\ndef',
+      'bar/baz': 'uvw\nxyz',
+    };
+    const targetPath = `${mockRoot}/out.js`;
+    writeObjectAsJavascriptModule(obj, targetPath);
+
+    const generatedFile = fs.readFileSync(targetPath, 'ascii');
+    const generated = eval(`${generatedFile}\nmodule.exports;`);
+
+    assert.equal(generated.foo, obj.foo, 'standard property');
+    assert.equal(generated['bar/baz'], obj['bar/baz'], 'quoted property');
+  });
+});
+
+describe('stripCommentsFromThrift', () => {
+  it('removes various comment lines', () => {
+    const data = `foo
+/* a
+ * b
+ */
+bar
+baz # comment
+fizz // comment
+#comment
+bat`;
+
+    const expected = `foo
+bar
+baz
+fizz
+bat`;
+    assert.equal(stripCommentsFromThrift(data), expected);
+  });
+  it("doesn't try to parse inline comments when quotes are found", () => {
+    let data = 'a = "foo" # comment';
+    assert.equal(stripCommentsFromThrift(data), data);
+
+    data = "a = '2' # comment";
+    assert.equal(stripCommentsFromThrift(data), data);
+  });
+});
+
+// generate a hierarchy in the mock filesystem
+function setUpNestedScenario(dirCount: number, filesPerDir: number): string[] {
+  const dirs = sequence(dirCount).map(i => `dir-${i}`);
+  dirs.forEach(dir => fs.mkdirSync(`${mockRoot}/${dir}`));
+  const files = [null, ...dirs].map(dir => {
+    return sequence(filesPerDir).map(i => {
+      const fileName = `file-${i}.tst`;
+      const filePath = dir ? `${dir}/${fileName}` : fileName;
+      fs.writeFileSync(`${mockRoot}/${filePath}`, `data-${i}-line-1\ndata-${i}-line-2`);
+      return filePath;
+    });
+  });
+  return flatten(files);
+}
+
+function flatten<T>(items: Array<T | Array<T>>): T[] {
+  const out: T[] = [];
+  items.forEach(item => {
+    if (Array.isArray(item)) {
+      out.push(...flatten(item));
+    } else {
+      out.push(item);
+    }
+  });
+  return out;
+}
+
+export function sequence(n: number): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < n; i++) {
+    out.push(i);
+  }
+  return out;
+}

--- a/test/tchannel_bridge.js
+++ b/test/tchannel_bridge.js
@@ -26,6 +26,7 @@ import TChannelBridge from '../src/tchannel_bridge.js';
 import TChannelAsThrift from 'tchannel/as/thrift';
 import TChannelAsJSON from 'tchannel/as/json';
 import combinations from './lib/combinations.js';
+import { convertDirectoryToJavascriptObject } from '../scripts/lib/javascriptifier';
 
 describe('test tchannel span bridge', () => {
   // BIG_TIMEOUT is useful for debugging purposes.
@@ -48,6 +49,8 @@ describe('test tchannel span bridge', () => {
     context: [ctx1, null],
     headers: [{}, null],
   });
+
+  let thriftData = convertDirectoryToJavascriptObject(`${__dirname}/thrift`, __dirname);
 
   _.each(options, o => {
     o.description = `as=${o.as}|mode=${o.mode}`;
@@ -80,7 +83,12 @@ describe('test tchannel span bridge', () => {
       // Wrap the subchannel in an encoding
       let encodedChannel = o.channelEncoding({
         channel: clientSubChannel,
-        entryPoint: path.join(__dirname, 'thrift', 'echo.thrift'), // ignored in json case
+        source:
+          thriftData['thrift/echo.thrift'] ||
+          (() => {
+            console.error(thriftData);
+            throw new Error(`path not found`);
+          }), // ignored in json case
       });
 
       let options: any = {};

--- a/test/udp_sender.js
+++ b/test/udp_sender.js
@@ -14,7 +14,6 @@ import _ from 'lodash';
 import { assert, expect } from 'chai';
 import ConstSampler from '../src/samplers/const_sampler.js';
 import dgram from 'dgram';
-import fs from 'fs';
 import path from 'path';
 import semver from 'semver';
 import InMemoryReporter from '../src/reporters/in_memory_reporter.js';
@@ -24,6 +23,7 @@ import Tracer from '../src/tracer.js';
 import { Thrift } from 'thriftrw';
 import ThriftUtils from '../src/thrift.js';
 import UDPSender from '../src/reporters/udp_sender.js';
+import ThriftData from '../src/generated/thrift';
 
 const PORT = 6832;
 
@@ -66,9 +66,9 @@ function createUdpSenderTest(options) {
       sender = new UDPSender({ host: options.host, socketType: options.socketType });
       sender.setProcess(reporter._process);
       thrift = new Thrift({
-        entryPoint: path.join(__dirname, '../src/thriftrw-idl/agent.thrift'),
+        entryPoint: 'thriftrw-idl/agent.thrift',
+        idls: ThriftData,
         allowOptionalArguments: true,
-        allowFilesystemAccess: true,
       });
     });
 


### PR DESCRIPTION
#303 
 Which problem is this PR solving?

Resolves [Issue 421](https://github.com/jaegertracing/jaeger-client-node/issues/421)  (client can't be used in webpack builds)

## Short description of the changes

- Add module to read thrift IDLs and generate a JavaScript module with an export named for each IDL path
- Add node CLI bootstrap to convert all IDLs in the client to a module using aforementioned module
- Add npm script to invoke node CLI to perform codegen
- Remove steps from makefile that copy IDLs to build destination
- Add step to makefile to run npm script
- update .gitignore to exclude codegen target "src/generated"


This PR adds JavaScript as part of the build process, which doesn't have an established convention for file locations in this repo. I took a stab, but this might not make sense, so I welcome guidance.

The code that parses the IDL into a JavaScript module includes a pretty trivial mechanism to strip out comments from the IDL source. They would become part of the memory footprint of this client when loaded statically. I believe this to be safe based on my reading of the IDL spec, but since this mechanism doesn't actually create an AST but just uses regexps, and the spec could change, this could be considered a risk. It seems likely tests would fail if this ever broke the IDL source, but the reason why might not be obvious. If there are any concerns about this, it's a pretty minor optimization which I'm can remove. Alternatives might be only remove very simple comments (line starts with hash), or alternatively, investigate some way to pre-parse the IDLs and distribute a compiled or optimized version. I couldn't see an obvious way to do this with `thriftrw-node` but perhaps there is. 
