### PR TITLE
feat(span-context): add open tracing methods to get span and trace id

### DIFF
--- a/src/span_context.js
+++ b/src/span_context.js
@@ -97,7 +97,7 @@ export default class SpanContext {
     }
     return this._spanIdStr;
   }
-
+  
   get parentIdStr(): ?string {
     if (this._parentIdStr == null && this._parentId != null) {
       this._parentIdStr = Utils.removeLeadingZeros(this._parentId.toString('hex'));
@@ -229,6 +229,20 @@ export default class SpanContext {
       this._debugId, // debugID
       this._samplingState // samplingState
     );
+  }
+
+  /**
+   * @return {string} - returns trace ID as string or "" if null
+   */
+  toTraceId(): string {
+    return this.traceIdStr || "";
+  }
+
+  /**
+   * @return {string} - returns span ID as string or "" if null
+   */
+  toSpanId(): string {
+    return this.spanIdStr || "";
   }
 
   /**

--- a/test/span_context.js
+++ b/test/span_context.js
@@ -148,4 +148,10 @@ describe('SpanContext', () => {
     context._setFirehose(false);
     assert.isFalse(context.isFirehose());
   });
+
+  it('should return span and trace id as strings', () => {
+    const context = SpanContext.fromString('ffffffffffffffffffffffffffffffff:ffffffffffffffff:5:1');;
+    assert.equal(context.toTraceId(), 'ffffffffffffffffffffffffffffffff');
+    assert.equal(context.toSpanId(), 'ffffffffffffffff');
+  });
 });


### PR DESCRIPTION
Signed-off-by: Sandes de Silva <sandes.samararatne@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

- https://github.com/jaegertracing/jaeger-client-node/issues/406

## Short description of the changes

- Add opentracing `toSpanId` and `toTraceId` methods to retrieve span ID and trace ID's respectively
