### PR TITLE
Pin tchannel to v3 for crossdock test

### DIFF
--- a/crossdock/Dockerfile
+++ b/crossdock/Dockerfile
@@ -12,5 +12,6 @@ ADD .babelrc /
 # Doing a full npm install inside the container would make this build really slow.
 # We pin tchannel to v3, because v4 removed support for Node-v0.10.
 RUN npm install tchannel@^3
+RUN npm ls
 
 CMD ["/crossdock/src/driver.sh"]

--- a/crossdock/Dockerfile
+++ b/crossdock/Dockerfile
@@ -11,7 +11,7 @@ ADD .babelrc /
 # We re-install tchannel because it is the only depenency that requires native code compilation.
 # Doing a full npm install inside the container would make this build really slow.
 # We pin tchannel to v3, because v4 removed support for Node-v0.10.
-RUN npm install tchannel@^3
+RUN npm install tchannel@3.9.13
 RUN npm ls
 
 CMD ["/crossdock/src/driver.sh"]

--- a/crossdock/Dockerfile
+++ b/crossdock/Dockerfile
@@ -10,6 +10,7 @@ ADD .babelrc /
 
 # We re-install tchannel because it is the only depenency that requires native code compilation.
 # Doing a full npm install inside the container would make this build really slow.
-RUN npm install tchannel
+# We pin tchannel to v3, because v4 removed support for Node-v0.10.
+RUN npm install tchannel@^3
 
 CMD ["/crossdock/src/driver.sh"]


### PR DESCRIPTION
## Which problem is this PR solving?
Fix for crossdock tests failing with
```
node_1         |     at Function.Module._load (module.js:311:12)
node_1         |     at Module.require (module.js:366:17)
node_1         |     at require (module.js:385:17)
node_1         |     at Object.<anonymous> (/node_modules/tchannel/v2/index.js:44:12)
node_1         | /node_modules/tchannel/v2/call.js:49
node_1         | var CN_VALUE = bufferFrom('cn').readUInt16BE(0, false);
node_1         |                ^
node_1         | 
node_1         | TypeError: this is not a typed array.
node_1         |     at from (native)
node_1         |     at Object.<anonymous> (/node_modules/tchannel/v2/call.js:49:16)
node_1         |     at Module._compile (module.js:435:26)
node_1         |     at Module._extensions..js (module.js:442:10)
node_1         |     at Object.require.extensions.(anonymous function) [as .js] (/node_modules/babel-register/lib/node.js:152:7)
node_1         |     at Module.load (module.js:356:32)
node_1         |     at Function.Module._load (module.js:311:12)
node_1         |     at Module.require (module.js:366:17)
node_1         |     at require (module.js:385:17)
node_1         |     at Object.<anonymous> (/node_modules/tchannel/v2/index.js:44:12)
```

## Short description of the changes
Pin tchannel to v3, because v4 removed support for Node 0.10