### PR TITLE
Document trace buffer flush interval and close

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ var tracer = initTracer(config, options);
 
 ## Usage
 
-The Tracer instance created by `initTracer` is OpenTracing-1.0 compliant. See [opentracing-javascript](https://github.com/opentracing/opentracing-javascript) for usage examples.
+The Tracer instance created by `initTracer` is OpenTracing-1.0 compliant. See [opentracing-javascript](https://github.com/opentracing/opentracing-javascript) for usage examples. Ensure that `tracer.close()` is called on application exit to flush buffered traces.
 
 ### TChannel Span Bridging
 
@@ -241,6 +241,16 @@ span.setTag('jaeger-debug-id', 'some-correlation-id');
 ```
 
 This allows using Jaeger UI to find the trace by this tag.
+
+### Trace Buffer
+
+Specify the reporter's flush interval (ms) with `config.reporter.flushIntervalMs` or `JAEGER_REPORTER_FLUSH_INTERVAL`. The default is 1000 ms.
+
+Calling `.close()` on the tracer will properly flush and close composed objects, including the reporter and sampler. This prevents dropped traces in the event of an error or unexpected early termination prior to normal periodic flushing.
+
+```javascript
+tracer.close(cb?)
+```
 
 ### Zipkin Compatibility
 


### PR DESCRIPTION
Signed-off-by: Justin Walz <justin.walz10@gmail.com>

Resolves https://github.com/jaegertracing/jaeger-client-node/issues/293
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

- I noticed that calling close() resolved some issues I was having locally, and found this ticket which is somewhat related https://github.com/jaegertracing/jaeger-client-node/issues/293.

## Short description of the changes

- Updated the README to include notes on these two pieces (flush interval and tracer.close().
