### PR TITLE
Replace docker-node-babel image that disappeared from Docker Hub

### DIFF
--- a/crossdock/Dockerfile
+++ b/crossdock/Dockerfile
@@ -1,4 +1,11 @@
-FROM woorank/docker-node-babel
+# 2020-07-16: the source image used to be woorank/docker-node-babel.
+#   However, it is no longer available from Docker Hub.
+#   It was republished from a local cache as jaegertracing/xdock-node:docker-node-babel.
+#     woorank/docker-node-babel                                        latest              1fef8ea9e76f        4 years ago         778MB
+#     jaegertracing/xdock-node                                         docker-node-babel   1fef8ea9e76f        4 years ago         778MB
+
+FROM jaegertracing/xdock-node:docker-node-babel
+
 EXPOSE 8080-8082
 
 ADD node_modules/ /node_modules


### PR DESCRIPTION
## Which problem is this PR solving?

- The builds started failing because the Docker image `woorank/docker-node-babel` used by crossdock build disappeared from Docker Hub.

## Short description of the changes

- I republished the copy of the image from my local repository. It is not clear what kind of image it was, probably built with Node 0.10 and an older version of Babel. It also seems to include Python2 without which the crossdock `docker build` fails now.
