### PR TITLE
Always read thrift defs from `./` to better support bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,23 @@ tracer.registerExtractor(opentracing.FORMAT_HTTP_HEADERS, codec);
 
 This can prove useful when compatibility with existing Zipkin tracing/instrumentation is desired.
 
+### Webpack Compatibility
+
+In order to bundle the library using webpack, e.g. for uploading code to an AWS Lambda function, it is required to copy the Jaeger thrift definition file into the output directory of the bundle:
+
+```js
+{
+  plugins: [
+    new CopyPlugin([
+      {
+        from: require.resolve('jaeger-client/dist/src/jaeger-idl/thrift/jaeger.thrift'),
+        to: 'jaeger-idl/thrift/jaeger.thrift',
+      },
+    ]),
+  ];
+}
+```
+
 ## License
 
 [Apache 2.0 License](./LICENSE).

--- a/src/reporters/http_sender.js
+++ b/src/reporters/http_sender.js
@@ -20,6 +20,7 @@ import { Thrift } from 'thriftrw';
 
 import NullLogger from '../logger.js';
 import SenderUtils from './sender_utils.js';
+import ThriftUtils from '../thrift.js';
 
 const DEFAULT_PATH = '/api/traces';
 const DEFAULT_PORT = 14268;
@@ -55,7 +56,7 @@ export default class HTTPSender {
 
     this._logger = options.logger || new NullLogger();
     this._jaegerThrift = new Thrift({
-      source: fs.readFileSync(path.join(__dirname, '../jaeger-idl/thrift/jaeger.thrift'), 'ascii'),
+      source: ThriftUtils.loadJaegerThriftDefinition(),
       allowOptionalArguments: true,
     });
 

--- a/src/reporters/udp_sender.js
+++ b/src/reporters/udp_sender.js
@@ -17,6 +17,7 @@ import path from 'path';
 import { Thrift } from 'thriftrw';
 import NullLogger from '../logger';
 import SenderUtils from './sender_utils';
+import ThriftUtils from '../thrift';
 import Utils from '../util';
 
 const HOST = 'localhost';
@@ -56,7 +57,7 @@ export default class UDPSender {
       allowFilesystemAccess: true,
     });
     this._jaegerThrift = new Thrift({
-      source: fs.readFileSync(path.join(__dirname, '../jaeger-idl/thrift/jaeger.thrift'), 'ascii'),
+      source: ThriftUtils.loadJaegerThriftDefinition(),
       allowOptionalArguments: true,
     });
     this._totalSpanBytes = 0;

--- a/src/thrift.js
+++ b/src/thrift.js
@@ -19,10 +19,14 @@ import Utils from './util.js';
 
 export default class ThriftUtils {
   static _thrift = new Thrift({
-    source: fs.readFileSync(path.join(__dirname, './jaeger-idl/thrift/jaeger.thrift'), 'ascii'),
+    source: ThriftUtils.loadJaegerThriftDefinition(),
     allowOptionalArguments: true,
   });
   static emptyBuffer: Buffer = Utils.newBuffer(8);
+
+  static loadJaegerThriftDefinition(): string {
+    return fs.readFileSync(path.join(__dirname, './jaeger-idl/thrift/jaeger.thrift'), 'ascii');
+  }
 
   static getThriftTags(initialTags: Array<Tag>): Array<any> {
     let thriftTags = [];

--- a/test/http_sender.js
+++ b/test/http_sender.js
@@ -53,7 +53,7 @@ describe('http sender', () => {
 
   beforeEach(() => {
     thrift = new Thrift({
-      source: fs.readFileSync(path.join(__dirname, '../src/jaeger-idl/thrift/jaeger.thrift'), 'ascii'),
+      source: ThriftUtils.loadJaegerThriftDefinition(),
       allowOptionalArguments: true,
     });
 


### PR DESCRIPTION
Always reading the jaeger thrift definition file from the root dir (i.e. `src`) allows consumers to bundle `jaeger-client`, e.g. for uploading code to an AWS lambda function.

To bundle `jaeger-client` with `webpack` for example, the thrift file needs to be copied into the output directory of the bundle like this:

```js
{
  plugins: [
    new CopyPlugin([
      {
        from: require.resolve(
          'jaeger-client/dist/src/jaeger-idl/thrift/jaeger.thrift'
        ),
        to: 'jaeger-idl/thrift/jaeger.thrift'
      }
    ])
  ]
}
```

With this in place `fs.readFileSync` will be able to find the file.

Signed-off-by: Hendrik Liebau <mail@hendrik-liebau.de>