### PR TITLE
Fix xorshift related deprection warning (resolves #422)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7485,6 +7485,12 @@
           "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
           "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
           "dev": true
+        },
+        "xorshift": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/xorshift/-/xorshift-0.2.1.tgz",
+          "integrity": "sha1-/NgiZ+k1HBPw+5xzMH8lMx0pxjo=",
+          "dev": true
         }
       }
     },
@@ -7961,9 +7967,9 @@
       }
     },
     "xorshift": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/xorshift/-/xorshift-0.2.1.tgz",
-      "integrity": "sha1-/NgiZ+k1HBPw+5xzMH8lMx0pxjo="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/xorshift/-/xorshift-1.1.1.tgz",
+      "integrity": "sha512-GMYHpzXeRwVXaHckrEbqqSNjNbms1oRSntP2weG4mrUMWAoLgF4b0ag/qqpYRbDEBfbC3Njt3+R5nX3lbP0Lww=="
     },
     "xregexp": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "opentracing": "^0.14.4",
     "thriftrw": "^3.5.0",
     "uuid": "^3.2.1",
-    "xorshift": "^0.2.0"
+    "xorshift": "^1.1.1"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Resolves #422 

When applications that use this module start with recent Node versions, a deprecation warning relating to `Buffer` is emitted. This is caused by the xorshift dependency.

There may be other deprecated Buffer usages, but only the first one will be logged. So I'm starting here.

## Short description of the changes

I upgraded xorshift to the lastest version, which doesn't make use of `Buffer` at all (and also doesn't rely on new dependencies for compatibility).