### PR TITLE
Add config for maxUdpPacketSize

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -148,6 +148,9 @@ export default class Configuration {
       if (config.reporter.agentSocketType) {
         senderConfig['socketType'] = config.reporter.agentSocketType;
       }
+      if (config.reporter.maxUdpPacketSize) {
+        senderConfig['maxPacketSize'] = config.reporter.maxUdpPacketSize;
+      }
     }
     reporterConfig['metrics'] = options.metrics;
     reporterConfig['logger'] = options.logger;

--- a/test/http_sender.js
+++ b/test/http_sender.js
@@ -242,7 +242,7 @@ describe('http sender', () => {
     // this test tends to timeout
     this.timeout(15000);
     sender = new HTTPSender({
-      endpoint: 'http://foo.bar.xyz',
+      endpoint: 'http://foo.bar.invalid',
       maxSpanBatchSize: batchSize,
     });
     sender.setProcess(reporter._process);

--- a/test/udp_sender.js
+++ b/test/udp_sender.js
@@ -268,7 +268,7 @@ function createUdpSenderTest(options) {
       // this test tends to timeout
       this.timeout(15000);
       let tracer = new Tracer('test-service-name', new RemoteReporter(sender), new ConstSampler(true));
-      sender._host = 'foo.bar.xyz';
+      sender._host = 'foo.bar.invalid';
       // In Node 0.10 and 0.12 the error is logged twice: (1) from inline callback, (2) from on('error') handler.
       let expectLogs = semver.satisfies(process.version, '0.10.x || 0.12.x');
       sender._logger = {


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

- The max udp packet size can differ between platforms. See https://github.com/jaegertracing/jaeger-client-node/issues/124#issuecomment-324222456
- In that thread, they increased the maximum packet size on the system, but sometimes it's easier to just have clients produce smaller packets if they can.

## Short description of the changes

- Make the maximum udp packet size configurable.


The tests were also failing, so there is also a small commit to fix some invalid hostnames to be invalid.