### PR TITLE
Sanitize namespace to match prom naming

### DIFF
--- a/src/metrics/prometheus.js
+++ b/src/metrics/prometheus.js
@@ -72,7 +72,7 @@ export default class PrometheusMetricsFactory {
     let key = name + ',' + labelNames.toString();
     let help = name;
     if (this._namespace) {
-      name = this._namespace + '_' + name;
+      name = this._namespace.replace(/-/g, '_') + '_' + name;
     }
     if (!(key in this._cache)) {
       this._cache[key] = new metric({ name, help, labelNames });


### PR DESCRIPTION
replace - by _ in order to match prometheus naming 

See https://github.com/jaegertracing/jaeger-client-node/pull/279

## Which problem is this PR solving?

Fix

```
Error: Invalid metric name
    at new Metric (/Users/dev/qwant/foundation/node_modules/prom-client/lib/metric.js:36:10)
    at new Counter (/Users/dev/qwant/foundation/node_modules/prom-client/lib/counter.js:12:1)
    at PrometheusMetricsFactory._createMetric (/Users/dev/qwant/foundation/node_modules/jaeger-client/dist/src/metrics/prometheus.js:102:28)
    at PrometheusMetricsFactory.createCounter (/Users/dev/qwant/foundation/node_modules/jaeger-client/dist/src/metrics/prometheus.js:117:42)
    at new Metrics (/Users/dev/qwant/foundation/node_modules/jaeger-client/dist/src/metrics/metrics.js:26:45)
    at initTracer (/Users/dev/qwant/foundation/node_modules/jaeger-client/dist/src/configuration.js:276:27)
    at bootstrap (/Users/dev/qwant/foundation/dist/src/main.js:16:20)
    at Object.<anonymous> (/Users/dev/qwant/foundation/dist/src/main.js:49:1)
```

## Short description of the changes

Replace "-" to "_"
