### PR TITLE
Report HTTP errors when flushing spans

### DIFF
--- a/src/reporters/http_sender.js
+++ b/src/reporters/http_sender.js
@@ -115,7 +115,14 @@ export default class HTTPSender {
     const req = requester(this._httpOptions, resp => {
       // consume response data to free up memory
       resp.resume();
-      SenderUtils.invokeCallback(callback, numSpans);
+
+      let error;
+      if (resp.statusCode >= 400) {
+        error = `error sending spans over HTTP: server responded with HTTP ${resp.statusCode}`;
+        this._logger.error(error);
+      }
+
+      SenderUtils.invokeCallback(callback, numSpans, error);
     });
 
     req.on('error', err => {


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Fixes the issue where the server might respond with an error (4xx, 5xx) but no feedback is given to the developer that can help them diagnose the issue.

Resolves #458

## Short description of the changes

- Uses the same pattern as on socket errors: builds an error message and calls the `logger.error()` method, as well as providing the error to the flush callback function. 
