### PR TITLE
Fix env parsing of falsy values (#460)

### DIFF
--- a/src/configuration_env.js
+++ b/src/configuration_env.js
@@ -38,7 +38,7 @@ export default class ConfigurationEnv {
   }
 
   static _getConfigValue(obj, key, defaultValue) {
-    return (obj && obj[key]) || defaultValue;
+    return obj && key in obj ? obj[key] : defaultValue;
   }
 
   static _getSamplerFromEnv(config) {
@@ -49,7 +49,7 @@ export default class ConfigurationEnv {
     }
 
     value = ConfigurationEnv._getConfigValue(config.sampler, 'param', process.env.JAEGER_SAMPLER_PARAM);
-    if (value) {
+    if (!isNaN(value)) {
       samplerConfig.param = parseFloat(value);
     }
 

--- a/test/init_tracer.js
+++ b/test/init_tracer.js
@@ -546,4 +546,27 @@ describe('initTracerFromENV', () => {
     assert.equal(tracer._tags['KEY2'], 'VALUE2');
     tracer.close(done);
   });
+
+  it('should parse falsy values from direct config setting', done => {
+    let config = {
+      serviceName: 'test-service-arg',
+      sampler: {
+        type: 'const',
+      },
+    };
+
+    let tracer;
+
+    expect(() => {
+      tracer = initTracerFromEnv(config);
+    }).to.throw();
+
+    config.sampler.param = 0;
+    expect(() => {
+      tracer = initTracerFromEnv(config);
+    }).to.not.throw();
+    assert.equal(tracer._sampler._decision, false);
+
+    tracer.close(done);
+  });
 });


### PR DESCRIPTION
Signed-off-by: Gerrit Kieffer <kieffer.gerrit@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

- Resolves #460

## Short description of the changes

- This is a re-issue of #461 (due to an incorrect source branch)
- Replace implicit boolean evaluation with explicit check in ternary operator / number check
