### PR TITLE
Stop testing with Node <v10; upgrade tchannel->4.x

### DIFF
--- a/.github/workflows/ci-crossdock.yml
+++ b/.github/workflows/ci-crossdock.yml
@@ -46,15 +46,11 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        npm install babel-cli
+        # npm install babel-cli
         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-        npm uninstall -D husky lint-staged
+        #npm uninstall -D husky lint-staged
         make build-node
-        rm -rf ./node_modules package-lock.json
-
-    # - uses: actions/setup-node@v2
-    #   with:
-    #     node-version: "0.10"
+        # rm -rf ./node_modules package-lock.json
 
     - name: Run Crossdock
       id: run-crossdock

--- a/.github/workflows/ci-crossdock.yml
+++ b/.github/workflows/ci-crossdock.yml
@@ -46,11 +46,8 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        # npm install babel-cli
         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-        #npm uninstall -D husky lint-staged
         make build-node
-        # rm -rf ./node_modules package-lock.json
 
     - name: Run Crossdock
       id: run-crossdock

--- a/.github/workflows/ci-crossdock.yml
+++ b/.github/workflows/ci-crossdock.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   crossdock:
     env:
-      NODE_LTS: "10"
+      NODE_LTS: "14"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -49,13 +49,12 @@ jobs:
         npm install babel-cli
         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
         npm uninstall -D husky lint-staged
-        make node-modules
         make build-node
         rm -rf ./node_modules package-lock.json
 
-    - uses: actions/setup-node@v2
-      with:
-        node-version: "0.10"
+    # - uses: actions/setup-node@v2
+    #   with:
+    #     node-version: "0.10"
 
     - name: Run Crossdock
       id: run-crossdock

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -10,17 +10,20 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     env:
-      NODE_LTS: "10"
+      # this must match NODE_LTS version in Makefile
+      NODE_LTS: "14"
     strategy:
       matrix:
         env:
+          # 0.10 is used for legacy reasons for crossdock tests
           - TEST_NODE_VERSION: "0.10"
-          - TEST_NODE_VERSION: "4"
-          - TEST_NODE_VERSION: "6"
           - TEST_NODE_VERSION: "10"
+          - TEST_NODE_VERSION: "12"
+          # current Active LTS, https://nodejs.org/en/about/releases/
+          - TEST_NODE_VERSION: "14"
             LINT: "1"
             COVER: "1"
-          - TEST_NODE_VERSION: "12"
+          - TEST_NODE_VERSION: "16"
     name: unit-tests - node ${{ matrix.env.TEST_NODE_VERSION }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -15,8 +15,6 @@ jobs:
     strategy:
       matrix:
         env:
-          # 0.10 is used for legacy reasons for crossdock tests
-          - TEST_NODE_VERSION: "0.10"
           - TEST_NODE_VERSION: "10"
           - TEST_NODE_VERSION: "12"
           # current Active LTS, https://nodejs.org/en/about/releases/
@@ -40,7 +38,6 @@ jobs:
       run: |
         npm install babel-cli
         npm uninstall -D husky lint-staged
-        make node-modules
         make build-node
         rm -rf ${{ github.workspace }}/node_modules/ ${{ github.workspace }}/package-lock.json    
 

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Current Active LTS is 14: https://nodejs.org/en/about/releases/.
-      # This must match LTS_NODE_VER in Makefile.
+      # This must match LTS_NODE_VER in Makefile and `.npmrc`.
       NODE_LTS: "14"
     strategy:
       matrix:

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -10,14 +10,14 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     env:
-      # this must match NODE_LTS version in Makefile
+      # Current Active LTS is 14: https://nodejs.org/en/about/releases/.
+      # This must match LTS_NODE_VER in Makefile.
       NODE_LTS: "14"
     strategy:
       matrix:
         env:
           - TEST_NODE_VERSION: "10"
           - TEST_NODE_VERSION: "12"
-          # current Active LTS, https://nodejs.org/en/about/releases/
           - TEST_NODE_VERSION: "14"
             LINT: "1"
             COVER: "1"
@@ -36,10 +36,8 @@ jobs:
 
     - name: Install Base Project
       run: |
-        npm install babel-cli
-        npm uninstall -D husky lint-staged
         make build-node
-        rm -rf ${{ github.workspace }}/node_modules/ ${{ github.workspace }}/package-lock.json    
+        rm -rf ${{ github.workspace }}/node_modules/ ${{ github.workspace }}/package-lock.json
 
     - name: Configure Test Node Version
       uses: actions/setup-node@v2

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/dubnium
+lts/fermium

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include crossdock/rules.mk
 
 NODE_VER=$(shell node -v)
-ifeq ($(patsubst v10.%,matched,$(NODE_VER)), matched)
+ifeq ($(patsubst v14.%,matched,$(NODE_VER)), matched)
 	NODE_LTS=true
 else
 	NODE_LTS=false

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,6 @@ ifeq ($(patsubst v$(LTS_NODE_VER).%,matched,$(NODE_VER)), matched)
 else
 	NODE_LTS=false
 endif
-# TODO remove
-ifeq ($(patsubst v0.10%,matched,$(NODE_VER)), matched)
-	NODE_0_10=true
-else
-	NODE_0_10=false
-endif
 
 .PHONY: publish
 publish: build-node
@@ -25,20 +19,13 @@ publish: build-node
 test: build-node test-without-build
 
 .PHONY: test-without-build
-test-without-build: install-test-deps
+test-without-build:
 	npm run flow
 ifeq ($(NODE_LTS),true)
 	npm run test-all
 endif
 	npm run test-dist
 	npm run check-license
-
-# TODO remove
-.PHONY: install-test-deps
-install-test-deps:
-ifeq ($(NODE_0_10), false)
-	echo skipping npm install --no-save prom-client@11.0.0
-endif
 
 .PHONY: check-node-lts
 check-node-lts:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 -include crossdock/rules.mk
 
+LTS_NODE_VER=14
 NODE_VER=$(shell node -v)
-ifeq ($(patsubst v14.%,matched,$(NODE_VER)), matched)
+ifeq ($(patsubst v$(LTS_NODE_VER).%,matched,$(NODE_VER)), matched)
 	NODE_LTS=true
 else
 	NODE_LTS=false
 endif
+# TODO remove
 ifeq ($(patsubst v0.10%,matched,$(NODE_VER)), matched)
 	NODE_0_10=true
 else
@@ -20,8 +22,7 @@ publish: build-node
 	# Update Changelog.md to relfect the newest version changes.
 
 .PHONY: test
-test: build-node
-	make test-without-build
+test: build-node test-without-build
 
 .PHONY: test-without-build
 test-without-build: install-test-deps
@@ -32,25 +33,17 @@ endif
 	npm run test-dist
 	npm run check-license
 
-.PHONY: test-without-install
-test-without-install: build-without-install
-	npm run flow
-ifeq ($(NODE_LTS),true)
-	npm run test-all
-endif
-	npm run test-dist
-	npm run check-license
-
+# TODO remove
 .PHONY: install-test-deps
 install-test-deps:
 ifeq ($(NODE_0_10), false)
-	npm install --no-save prom-client@11.0.0
+	echo skipping npm install --no-save prom-client@11.0.0
 endif
 
 .PHONY: check-node-lts
 check-node-lts:
-	@$(NODE_LTS) || echo Build requires Node 10.x
-	@$(NODE_LTS) && echo Building using Node 10.x
+	@$(NODE_LTS) || echo Build requires Node v$(LTS_NODE_VER)
+	@$(NODE_LTS) && echo Building using Node v$(LTS_NODE_VER)
 
 .PHONY: build-node
 build-node: check-node-lts node-modules build-without-install

--- a/crossdock/Dockerfile
+++ b/crossdock/Dockerfile
@@ -1,17 +1,9 @@
-# 2020-07-16: the source image used to be woorank/docker-node-babel.
-#   However, it is no longer available from Docker Hub.
-#   It was republished from a local cache as jaegertracing/xdock-node:docker-node-babel.
-#     woorank/docker-node-babel                                        latest              1fef8ea9e76f        4 years ago         778MB
-#     jaegertracing/xdock-node                                         docker-node-babel   1fef8ea9e76f        4 years ago         778MB
-
-# FROM jaegertracing/xdock-node:docker-node-babel
-
 FROM node:14-alpine
+
 RUN apk update && apk add python g++ make bash && rm -rf /var/cache/apk/*
 
 EXPOSE 8080-8082
 
-# ADD node_modules/ /node_modules
 ADD package.json /
 ADD package-lock.json /
 ADD src/ /src
@@ -19,11 +11,6 @@ ADD src/jaeger-idl/thrift/crossdock/tracetest.thrift /crossdock/tracetest.thrift
 ADD crossdock/src/ /crossdock/src
 ADD .babelrc /
 
-# We re-install tchannel because it is the only depenency that requires native code compilation.
-# Doing a full npm install inside the container would make this build really slow.
-# RUN npm install tchannel@4
 RUN npm install
-RUN npm ls
-RUN node -v
 
 CMD ["/bin/bash", "/crossdock/src/driver.sh"]

--- a/crossdock/Dockerfile
+++ b/crossdock/Dockerfile
@@ -4,21 +4,26 @@
 #     woorank/docker-node-babel                                        latest              1fef8ea9e76f        4 years ago         778MB
 #     jaegertracing/xdock-node                                         docker-node-babel   1fef8ea9e76f        4 years ago         778MB
 
-FROM jaegertracing/xdock-node:docker-node-babel
+# FROM jaegertracing/xdock-node:docker-node-babel
+
+FROM node:14-alpine
+RUN apk update && apk add python g++ make bash && rm -rf /var/cache/apk/*
 
 EXPOSE 8080-8082
 
-ADD node_modules/ /node_modules
+# ADD node_modules/ /node_modules
 ADD package.json /
+ADD package-lock.json /
 ADD src/ /src
 ADD src/jaeger-idl/thrift/crossdock/tracetest.thrift /crossdock/tracetest.thrift
-ADD crossdock/src /crossdock/src
+ADD crossdock/src/ /crossdock/src
 ADD .babelrc /
 
 # We re-install tchannel because it is the only depenency that requires native code compilation.
 # Doing a full npm install inside the container would make this build really slow.
-# We pin tchannel to v3, because v4 removed support for Node-v0.10.
-RUN npm install tchannel@3.9.13
+# RUN npm install tchannel@4
+RUN npm install
 RUN npm ls
+RUN node -v
 
-CMD ["/crossdock/src/driver.sh"]
+CMD ["/bin/bash", "/crossdock/src/driver.sh"]

--- a/crossdock/Dockerfile
+++ b/crossdock/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:14-alpine
 
+# tchannel uses node-gyp to compile native libs, which requires python.
 RUN apk update && apk add python g++ make bash && rm -rf /var/cache/apk/*
 
 EXPOSE 8080-8082

--- a/crossdock/rules.mk
+++ b/crossdock/rules.mk
@@ -2,15 +2,13 @@ PROJECT=crossdock
 XDOCK_YAML=$(PROJECT)/docker-compose.yml
 
 .PHONY: crossdock
-crossdock: install_node_modules
-	docker-compose -f $(XDOCK_YAML) kill node
+crossdock: install_node_modules crossdock-kill
 	docker-compose -f $(XDOCK_YAML) rm -f node
 	docker-compose -f $(XDOCK_YAML) build node
 	docker-compose -f $(XDOCK_YAML) run crossdock
 
 .PHONY: crossdock-fresh
-crossdock-fresh: install_node_modules
-	docker-compose -f $(XDOCK_YAML) kill
+crossdock-fresh: install_node_modules crossdock-kill
 	docker-compose -f $(XDOCK_YAML) rm --force
 	docker-compose -f $(XDOCK_YAML) pull
 	docker-compose -f $(XDOCK_YAML) build --no-cache
@@ -20,16 +18,11 @@ crossdock-fresh: install_node_modules
 crossdock-logs:
 	docker-compose -f $(XDOCK_YAML) logs
 
+.PHONY: crossdock-kill
+crossdock-kill:
+	docker-compose -f $(XDOCK_YAML) kill
+
 .PHONY: install_node_modules
 install_node_modules:
-	npm install
-	npm uninstall tchannel
-
-.PHONY: install_docker_ci
-install_docker_ci:
-	@echo "Installing docker-compose $${DOCKER_COMPOSE_VERSION:?'DOCKER_COMPOSE_VERSION env not set'}"
-	sudo rm -f /usr/local/bin/docker-compose
-	curl -L https://github.com/docker/compose/releases/download/$${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-	chmod +x docker-compose
-	sudo mv docker-compose /usr/local/bin
-	docker-compose version
+	echo skipping npm install
+	echo skipping npm uninstall tchannel

--- a/crossdock/rules.mk
+++ b/crossdock/rules.mk
@@ -2,13 +2,13 @@ PROJECT=crossdock
 XDOCK_YAML=$(PROJECT)/docker-compose.yml
 
 .PHONY: crossdock
-crossdock: install_node_modules crossdock-kill
+crossdock: crossdock-kill
 	docker-compose -f $(XDOCK_YAML) rm -f node
 	docker-compose -f $(XDOCK_YAML) build node
 	docker-compose -f $(XDOCK_YAML) run crossdock
 
 .PHONY: crossdock-fresh
-crossdock-fresh: install_node_modules crossdock-kill
+crossdock-fresh: crossdock-kill
 	docker-compose -f $(XDOCK_YAML) rm --force
 	docker-compose -f $(XDOCK_YAML) pull
 	docker-compose -f $(XDOCK_YAML) build --no-cache
@@ -21,8 +21,3 @@ crossdock-logs:
 .PHONY: crossdock-kill
 crossdock-kill:
 	docker-compose -f $(XDOCK_YAML) kill
-
-.PHONY: install_node_modules
-install_node_modules:
-	echo skipping npm install
-	echo skipping npm uninstall tchannel

--- a/crossdock/src/driver.sh
+++ b/crossdock/src/driver.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
+set -x
+
 /node_modules/.bin/babel-node /crossdock/src/http_server.js &
 /node_modules/.bin/babel-node /crossdock/src/tchannel_server.js &
 
-sleep 10
+# unfortunately, we do not check that the above two servers are ready
+# before starting the healthcheck handler, so give them some time.
+sleep 20
+
 /node_modules/.bin/babel-node /crossdock/src/healthcheck_server.js &
 
 sleep infinity

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,6 +162,22 @@
       "integrity": "sha512-91IFKeKk7FjfmezPKkwtaRvSpnUc4gDwPAjA1YZ9Gn0q0PPeW+vbeUsZuyDwjI7+QTHhcLen2v25fi/AmhvbJA==",
       "dev": true
     },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1117,9 +1133,9 @@
       }
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
     "bcrypt-pbkdf": {
@@ -1162,6 +1178,12 @@
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=",
+      "dev": true
     },
     "bl": {
       "version": "1.1.2",
@@ -1305,13 +1327,13 @@
       }
     },
     "buffer": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-from": {
@@ -1448,6 +1470,12 @@
         "path-is-absolute": "^1.0.0",
         "readdirp": "^2.0.0"
       }
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
     },
     "ci-info": {
       "version": "1.6.0",
@@ -1668,6 +1696,12 @@
         }
       }
     },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
+    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -1879,6 +1913,15 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^2.0.0"
+      }
+    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -1982,6 +2025,12 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -2002,6 +2051,12 @@
       "requires": {
         "repeating": "^2.0.0"
       }
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "dev": true
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -2081,6 +2136,15 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "error": {
       "version": "7.0.2",
@@ -2601,6 +2665,12 @@
         "fill-range": "^2.1.0"
       }
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true
+    },
     "express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -2694,12 +2764,13 @@
       "dev": true
     },
     "farmhash": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/farmhash/-/farmhash-1.2.1.tgz",
-      "integrity": "sha1-Lb8SYE71yh8UIPtmAPzLMNVHTf0=",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/farmhash/-/farmhash-3.2.1.tgz",
+      "integrity": "sha512-WCJKzFIndN6J/iesO/aHEtr772M3IQpwkwzEQK8rRMI+H+LBpi+VW8qWroXKnZmGDlHwbR0mMzEr2Eov5Jx/Pg==",
       "dev": true,
       "requires": {
-        "nan": "^2.4.0"
+        "node-addon-api": "^3.1.0",
+        "prebuild-install": "^6.0.1"
       }
     },
     "fast-deep-equal": {
@@ -2928,6 +2999,12 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -2961,8 +3038,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2983,14 +3059,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3005,20 +3079,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3135,8 +3206,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3148,7 +3218,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3163,7 +3232,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3171,14 +3239,12 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3197,7 +3263,6 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -3259,8 +3324,7 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -3288,8 +3352,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3301,7 +3364,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3379,8 +3441,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3416,7 +3477,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3436,7 +3496,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3480,14 +3539,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3502,6 +3559,44 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
+      }
     },
     "generate-function": {
       "version": "2.3.1",
@@ -3562,6 +3657,12 @@
         }
       }
     },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -3592,7 +3693,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -3748,6 +3848,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "has-value": {
@@ -3929,9 +4035,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
     "ignore": {
@@ -4202,8 +4308,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-finite": {
       "version": "1.1.0",
@@ -4228,7 +4333,6 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -5201,6 +5305,12 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
+    "mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -5253,6 +5363,12 @@
           "dev": true
         }
       }
+    },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true
     },
     "mocha": {
       "version": "3.5.3",
@@ -5348,7 +5464,8 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -5389,6 +5506,12 @@
         }
       }
     },
+    "napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -5401,6 +5524,21 @@
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
       "dev": true
     },
+    "node-abi": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.26.0.tgz",
+      "integrity": "sha512-ag/Vos/mXXpWLLAYWsAoQdgS+gW7IwvgMLOgqopm/DbzAjazLltzgzpVMsFlgmo9TzG5hGXeaBZx2AI731RIsQ==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.4.1"
+      }
+    },
+    "node-addon-api": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
+      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==",
+      "dev": true
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5410,6 +5548,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
+      "dev": true
+    },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
       "dev": true
     },
     "nopt": {
@@ -5449,7 +5593,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -5481,6 +5624,18 @@
         "commander": "^2.9.0",
         "npm-path": "^2.0.2",
         "which": "^1.2.10"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -5945,6 +6100,39 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "prebuild-install": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.2.tgz",
+      "integrity": "sha512-PzYWIKZeP+967WuKYXlTOhYBgGOvTRSfaKI89XnfJ0ansRAH7hDU45X+K+FZeI1Wb/7p/NnuctPH3g0IqKUuSQ==",
+      "dev": true,
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.21.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^3.0.3",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "dependencies": {
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -6020,6 +6208,15 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "prom-client": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.0.0.tgz",
+      "integrity": "sha512-UM4uYDwmA7x9yTq+AZcL4lU/XF11RkbQWbIouFaVMLxdV4qBB5CEmEosQlR1lGvduBuS1IWonHFh1WBtFSoZ3A==",
+      "dev": true,
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "prop-types": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -6046,6 +6243,16 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "punycode": {
       "version": "1.4.1",
@@ -6578,8 +6785,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -6732,9 +6938,9 @@
       "dev": true
     },
     "run-series": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.8.tgz",
-      "integrity": "sha512-+GztYEPRpIsQoCSraWHDBs9WVy4eVME16zhOtDB4H9J4xN0XRhknnmLOl+4gRgZtu8dpp9N/utSPjKH/xmDzXg==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.9.tgz",
+      "integrity": "sha512-Arc4hUN896vjkqCYrUXquBFtRZdv1PfLbTYP71efP6butxyQ0kWpiNJyAgsxscmQg1cqvHY32/UCBzXedTpU2g==",
       "dev": true
     },
     "rust-result": {
@@ -6870,6 +7076,12 @@
         "send": "0.17.1"
       }
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
     "set-value": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -6929,6 +7141,23 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true
+    },
+    "simple-get": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "dev": true,
+      "requires": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "sinon": {
       "version": "1.17.7",
@@ -7162,13 +7391,21 @@
       "dev": true
     },
     "sse4_crc32": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/sse4_crc32/-/sse4_crc32-5.4.0.tgz",
-      "integrity": "sha512-sNCs25xYaKRyMcqUNej7NATXQDkSaRlh6cqd/0KzboDKIqvVG30BnRZP295U/GliTmTCBkYS7Wl9mw7a76bKIQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/sse4_crc32/-/sse4_crc32-6.0.1.tgz",
+      "integrity": "sha512-FUTYXpLroqytNKWIfHzlDWoy9E4tmBB/RklNMy6w3VJs+/XEYAHgbiylg4SS43iOk/9bM0BlJ2EDpFAGT66IoQ==",
       "dev": true,
       "requires": {
-        "bindings": "~1.5.0",
-        "nan": "2.14.0"
+        "bindings": "^1.3.0",
+        "node-addon-api": "^1.3.0"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+          "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+          "dev": true
+        }
       }
     },
     "sshpk": {
@@ -7448,50 +7685,120 @@
         }
       }
     },
-    "tape-cluster": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tape-cluster/-/tape-cluster-2.1.0.tgz",
-      "integrity": "sha1-C+FBuDN09fXSX4wwfL45FrfcR/4=",
-      "dev": true
+    "tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "tchannel": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/tchannel/-/tchannel-3.10.1.tgz",
-      "integrity": "sha512-hC5Ju9erF4DGBppnrhD+DEBKXvRJMU1EVq1ukKYgTR+8NJ5WBGmmTHdL9oMd76PyWpeOkKV2qXp9IQ64zzJ4Rw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/tchannel/-/tchannel-4.0.1.tgz",
+      "integrity": "sha512-1hmOhv6/mC7XRWYpo7EYOBFCkbb6NC662MpWiswJkJixwlCrae314tEaT6vwxIZtI0GsbzwcFQmnG8wStRZelA==",
       "dev": true,
       "requires": {
         "bufrw": "^1.2.1",
         "crc": "^3.8.0",
         "error": "^7.0.1",
-        "farmhash": "^1",
-        "json-stringify-safe": "^5.0.0",
-        "metrics": "^0.1.8",
-        "minimist": "^1.1.0",
+        "farmhash": "^3.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "metrics": "^0.1.21",
+        "minimist": "^1.2.0",
         "process": "^0.11.10",
-        "raw-body": "^2.1.2",
-        "ready-signal": "^1.1.1",
-        "run-parallel": "^1.1.0",
-        "run-series": "^1.1.2",
+        "raw-body": "^2.4.1",
+        "ready-signal": "^1.3.0",
+        "run-parallel": "^1.1.9",
+        "run-series": "^1.1.8",
         "safe-json-parse": "^4.0.0",
-        "sse4_crc32": "^5",
-        "tape-cluster": "2.1.0",
+        "sse4_crc32": "^6.0.1",
         "thriftrw": "^3.12.0",
-        "xorshift": "^0.2.0",
-        "xtend": "^4.0.0"
+        "xorshift": "^1.1.1",
+        "xtend": "^4.0.2"
       },
       "dependencies": {
+        "http-errors": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
         "process": {
           "version": "0.11.10",
           "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
           "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
           "dev": true
         },
-        "xorshift": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/xorshift/-/xorshift-0.2.1.tgz",
-          "integrity": "sha1-/NgiZ+k1HBPw+5xzMH8lMx0pxjo=",
-          "dev": true
+        "raw-body": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+          "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+          "dev": true,
+          "requires": {
+            "bytes": "3.1.0",
+            "http-errors": "1.7.3",
+            "iconv-lite": "0.4.24",
+            "unpipe": "1.0.0"
+          }
         }
+      }
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "dev": true,
+      "requires": {
+        "bintrees": "1.0.1"
       }
     },
     "text-table": {
@@ -7886,6 +8193,15 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
       }
     },
     "widest-line": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.18.2dev",
   "description": "Jaeger binding for OpenTracing API for Node.js",
   "engines": {
-    "node": ">=0.10"
+    "node": ">=10"
   },
   "license": "Apache-2.0",
   "keywords": [],
@@ -49,12 +49,13 @@
     "minimist": "1.2.3",
     "mocha": "^3.0.1",
     "prettier": "1.10.2",
+    "prom-client": "11.0.0",
     "request": "2.74.0",
     "rsvp": "^3.3.1",
     "semver": "^5",
     "sinon": "^1.17.5",
     "source-map-support": "^0.4.5",
-    "tchannel": "^3.9.0",
+    "tchannel": "^4",
     "uber-licence": "^2.0.2",
     "underscore": "^1.8.3"
   },


### PR DESCRIPTION
## Which problem is this PR solving?

- the CI no longer succeeds with Node 4
- v10 is EOL in a few days

## Short description of the changes

- upgrade tchannel to 4.x to remove dependency on Node 0.10 (YAY!)
- remove all Node versions earlier than v10; add versions 12, 14, 16
- make Node v14 the primary
- use official node/14-alpine base image for crossdock instead of hacky `jaegertracing/xdock-node:docker-node-babel` which has no source (see #439)
  - turns out doing npm install is not that slow in Docker
- clean-up GH actions and Make targets which had many unnecessary installs/uninstalls
