### PR TITLE
Update uuid package to latest stable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8146,9 +8146,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8flags": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node-int64": "^0.4.0",
     "opentracing": "^0.14.4",
     "thriftrw": "^3.5.0",
-    "uuid": "^3.2.1",
+    "uuid": "^8.3.2",
     "xorshift": "^1.1.1"
   },
   "devDependencies": {

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -14,7 +14,7 @@
 import * as opentracing from 'opentracing';
 import { Tags as otTags } from 'opentracing';
 import os from 'os';
-import uuidv4 from 'uuid/v4';
+import { v4 as uuidv4 } from 'uuid';
 import BaggageSetter from './baggage/baggage_setter';
 import DefaultBaggageRestrictionManager from './baggage/default_baggage_restriction_manager';
 import * as constants from './constants';


### PR DESCRIPTION
## Which problem is this PR solving?

Projects using `jaeger-client` cannot use `uuid` because of breaking changes since v3.x

## Short description of the changes
- Update uuid to latest stable version
