### PR TITLE
Simplify bundling udp_sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,10 @@ In order to bundle the library using webpack, e.g. for uploading code to an AWS 
         from: require.resolve('jaeger-client/dist/src/jaeger-idl/thrift/jaeger.thrift'),
         to: 'jaeger-idl/thrift/jaeger.thrift',
       },
+      {
+        from: require.resolve('jaeger-client/dist/src/thriftrw-idl/agent.thrift'),
+        to: 'thriftrw-idl/agent.thrift',
+      },
     ]),
   ];
 }

--- a/crossdock/test/endtoend_handler.js
+++ b/crossdock/test/endtoend_handler.js
@@ -17,6 +17,7 @@ import EndToEndHandler from '../src/endtoend_handler';
 import path from 'path';
 import request from 'request';
 import JaegerTestUtils from '../../src/test_util';
+import ThriftUtils from '../../src/thrift';
 import { Thrift } from 'thriftrw';
 import bodyParser from 'body-parser';
 import express from 'express';
@@ -32,7 +33,7 @@ describe('Endtoend Handler should', () => {
     server = dgram.createSocket('udp4');
     server.bind(PORT, HOST);
     thrift = new Thrift({
-      entryPoint: path.join(__dirname, '../../src/thriftrw-idl/agent.thrift'),
+      entryPoint: ThriftUtils.buildAgentThriftPath(),
       allowOptionalArguments: true,
       allowFilesystemAccess: true,
     });

--- a/src/reporters/udp_sender.js
+++ b/src/reporters/udp_sender.js
@@ -52,7 +52,7 @@ export default class UDPSender {
       this._logger.error(`error sending spans over UDP: ${err}`);
     });
     this._agentThrift = new Thrift({
-      entryPoint: path.join(__dirname, '../thriftrw-idl/agent.thrift'),
+      entryPoint: ThriftUtils.buildAgentThriftPath(),
       allowOptionalArguments: true,
       allowFilesystemAccess: true,
     });

--- a/src/thrift.js
+++ b/src/thrift.js
@@ -28,6 +28,10 @@ export default class ThriftUtils {
     return fs.readFileSync(path.join(__dirname, './jaeger-idl/thrift/jaeger.thrift'), 'ascii');
   }
 
+  static buildAgentThriftPath(): string {
+    return path.join(__dirname, './thriftrw-idl/agent.thrift');
+  }
+
   static getThriftTags(initialTags: Array<Tag>): Array<any> {
     let thriftTags = [];
     for (let i = 0; i < initialTags.length; i++) {

--- a/test/udp_sender.js
+++ b/test/udp_sender.js
@@ -66,7 +66,7 @@ function createUdpSenderTest(options) {
       sender = new UDPSender({ host: options.host, socketType: options.socketType });
       sender.setProcess(reporter._process);
       thrift = new Thrift({
-        entryPoint: path.join(__dirname, '../src/thriftrw-idl/agent.thrift'),
+        entryPoint: ThriftUtils.buildAgentThriftPath(),
         allowOptionalArguments: true,
         allowFilesystemAccess: true,
       });


### PR DESCRIPTION
## Which problem is this PR solving?
Bundling with webpack / esbuild is hard due to the use of `__dirname + "../"` for the udp sender.

## Short description of the changes
Add a helper function in src/thrift.js that returns an absolute path to
agent.thrift, without using "../". This is done to simplify bundling with
webpack or esbuild: assume an app is bundled to /app/index.js, if we resolve
a path to "../thrift-idl/etc", the file will be loaded from /thrift-idl/etc,
which is at the root of the filesystem.

Adjust README to support udp-sender.

This commit is a continuation of #441.
