### PR TITLE
Bind to localhost instead of INADDR_ANY for local reporter UDP socket creation

### DIFF
--- a/src/_flow/socket.js
+++ b/src/_flow/socket.js
@@ -13,6 +13,7 @@
 
 declare class dgram$Socket {
   on(event: string, listener: Function): this;
+  bind(port?: number, address?: string): void;
   close(): void;
   send(
     msg: Buffer,

--- a/src/reporters/udp_sender.js
+++ b/src/reporters/udp_sender.js
@@ -48,6 +48,10 @@ export default class UDPSender {
     this._maxPacketSize = options.maxPacketSize || UDP_PACKET_MAX_LENGTH;
     this._logger = options.logger || new NullLogger();
     this._client = dgram.createSocket(this._socketType);
+    if (this._host == 'localhost') {
+      // When the agent runs locally, we attach our UDP socket to localhost (as opposed to 0.0.0.0)
+      this._client.bind(0, 'localhost');
+    }
     this._client.on('error', err => {
       this._logger.error(`error sending spans over UDP: ${err}`);
     });


### PR DESCRIPTION
Before this change, we always bound UDP to all interfaces (::0 and 0.0.0.0) to
create an ephemeral port for reporting. Binding to INADDR_ANY for UDP ports
increases the attack surface for potential denial of service since INADDR_ANY
UDP ports will always accept all traffic that comes its way.

The proposed fix is to only bind to localhost for both ipv4 and ipv6, when the
configured HOST is localhost. For other hosts, we can't easily tell if we have
to bind to INADDR_ANY.

I understand that since we're using an ephemeral port the risk isn't quite as
big for DoS as a privileged port, however we're doing some network cleanup and
found that a few of our applications unnecessarily use INADDR_ANY, so making
this fix would clean up a lot of these patterns.

(Sorry, I'm not sure how to add a test for this -- I have tested this change manually on my server and it seems to behave as expected)

## Short description of the changes
- UDP Reporter won't create sockets on 0.0.0.0 by default.